### PR TITLE
Replace constructor by static create() method

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -84,10 +84,15 @@ class Chain implements ArrayAccess, IteratorAggregate
 
     /**
      * @param array $array
+     *
+     * @return Chain
      */
-    public function __construct(array $array = [])
+    public static function create(array $array = [])
     {
-        $this->array = $array;
+        $chain = new self();
+        $chain->array = $array;
+
+        return $chain;
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -80,7 +80,7 @@ class Chain implements ArrayAccess, IteratorAggregate
     /**
      * @var array
      */
-    public $array;
+    public $array = [];
 
     /**
      * @param array $array
@@ -89,7 +89,7 @@ class Chain implements ArrayAccess, IteratorAggregate
      */
     public static function create(array $array = [])
     {
-        $chain = new self();
+        $chain = new static();
         $chain->array = $array;
 
         return $chain;

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -16,11 +16,11 @@ class ChainTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test
-     * @covers Cocur\Chain\Chain::__construct()
+     * @covers Cocur\Chain\Chain::create()
      */
-    public function constructorCreatesChain()
+    public function createCreatesChain()
     {
-        $this->assertEquals([1, 2, 3], (new Chain([1, 2, 3]))->array);
+        $this->assertEquals([1, 2, 3], Chain::create([1, 2, 3])->array);
     }
 
     /**
@@ -69,7 +69,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
     public function chainIsTraversable()
     {
         $data = ['a', 'b'];
-        $c = new Chain($data);
+        $c = Chain::create($data);
 
         $this->assertInstanceOf('\Traversable', $c);
 
@@ -87,7 +87,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
      */
     public function chainAllowsArrayAccess()
     {
-        $c = new Chain();
+        $c = Chain::create();
 
         $this->assertFalse(isset($c[0]));
         $c[0] = 'foo';

--- a/tests/Link/CombineTest.php
+++ b/tests/Link/CombineTest.php
@@ -23,8 +23,8 @@ class CombineTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\Combine $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\Combine');
 
-        $keys   = new Chain(['foo', 'bar']);
-        $values = new Chain([42, 43]);
+        $keys   = Chain::create(['foo', 'bar']);
+        $values = Chain::create([42, 43]);
 
         $this->assertEquals(['foo' => 42, 'bar' => 43], $mock->combine($keys, $values)->array);
     }

--- a/tests/Link/DiffTest.php
+++ b/tests/Link/DiffTest.php
@@ -37,7 +37,7 @@ class DiffTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\Diff $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\Diff');
         $mock->array = [0, 1, 2];
-        $mock->diff(new Chain([1, 2, 3]));
+        $mock->diff(Chain::create([1, 2, 3]));
 
         $this->assertEquals([0], $mock->array);
     }

--- a/tests/Link/IntersectAssocTest.php
+++ b/tests/Link/IntersectAssocTest.php
@@ -40,7 +40,7 @@ class IntersectAssocTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\IntersectAssoc $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\IntersectAssoc');
         $mock->array = [1, 2, 3];
-        $mock->intersectAssoc(new Chain([3, 2, 1]));
+        $mock->intersectAssoc(Chain::create([3, 2, 1]));
 
         $this->assertContains(2, $mock->array);
         $this->assertNotContains(1, $mock->array);

--- a/tests/Link/IntersectKeyTest.php
+++ b/tests/Link/IntersectKeyTest.php
@@ -38,7 +38,7 @@ class IntersectKeyTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\IntersectKey $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\IntersectKey');
         $mock->array = ['a' => 1, 'b' => 2, 'c' => 3];
-        $mock->intersectKey(new Chain(['a' => 3, 'b' => 4, 'd' => 5]));
+        $mock->intersectKey(Chain::create(['a' => 3, 'b' => 4, 'd' => 5]));
 
         $this->assertEquals(['a' => 1, 'b' => 2], $mock->array);
     }

--- a/tests/Link/IntersectTest.php
+++ b/tests/Link/IntersectTest.php
@@ -39,7 +39,7 @@ class IntersectTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\Intersect $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\Intersect');
         $mock->array = [1, 2, 3];
-        $mock->intersect(new Chain([3, 4, 5]));
+        $mock->intersect(Chain::create([3, 4, 5]));
 
         $this->assertContains(3, $mock->array);
         $this->assertNotContains(1, $mock->array);

--- a/tests/Link/MergeTest.php
+++ b/tests/Link/MergeTest.php
@@ -37,7 +37,7 @@ class MergeTest extends PHPUnit_Framework_TestCase
         /** @var \Cocur\Chain\Link\Merge $mock */
         $mock = $this->getMockForTrait('Cocur\Chain\Link\Merge');
         $mock->array = [0, 1, 2];
-        $mock->merge(new Chain([3, 4]));
+        $mock->merge(Chain::create([3, 4]));
 
         $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
     }


### PR DESCRIPTION
By using a static create() method the Chain class can be more easily extended by
other classes. For example, some specific collection class might want to use the
functionality of Chain.

Another possibility would be to move the basic Chain functionality (the use statements, iterators, etc) to an abstract class (e.g., `AbstractChain`) and leave only the constructor in the `Chain`class (which would extend `AbstractChain`.

What do you think? @gries 