### PR TITLE
Add support for assoc and reverse sort

### DIFF
--- a/src/Link/Sort.php
+++ b/src/Link/Sort.php
@@ -5,28 +5,63 @@ namespace Cocur\Chain\Link;
 use Cocur\Chain\Chain;
 
 /**
- * Class Sort
+ * Sort
  *
  * @package     Cocur\Chain\Link
  * @author      Christoph Rosse
+ * @author      Florian Eckerstorfer <florian@eckerstorfer.co>
  */
 trait Sort
 {
     /**
      * Sort a Chain
      **
-     * @param int|callable $options
+     * @param int|callable $sortBy
+     * @param array        $options
      *
      * @return Chain
      */
-    public function sort($options = SORT_REGULAR)
+    public function sort($sortBy = SORT_REGULAR, array $options = [])
     {
-        if ($options && is_callable($options)) {
-            usort($this->array, $options);
+        if (!$sortBy) {
+            $sortBy = SORT_REGULAR;
+        }
+        if ($sortBy && is_callable($sortBy)) {
+            $this->sortWithCallback($sortBy, $options);
         } else {
-            sort($this->array, $options);
+            $this->sortWithFlags($sortBy, $options);
         }
 
         return $this;
+    }
+
+    /**
+     * @param callable $callback
+     * @param array    $options
+     */
+    private function sortWithCallback(callable $callback, array $options = [])
+    {
+        if (isset($options['assoc']) && $options['assoc']) {
+            uasort($this->array, $callback);
+        } else {
+            usort($this->array, $callback);
+        }
+    }
+
+    /**
+     * @param int   $sortFlags
+     * @param array $options
+     */
+    private function sortWithFlags($sortFlags = SORT_REGULAR, array $options = [])
+    {
+        if (!empty($options['assoc']) && !empty($options['reverse'])) {
+            arsort($this->array, $sortFlags);
+        } else if (!empty($options['assoc'])) {
+            asort($this->array, $sortFlags);
+        } else if (!empty($options['reverse'])) {
+            rsort($this->array, $sortFlags);
+        } else {
+            sort($this->array, $sortFlags);
+        }
     }
 }

--- a/src/Link/Sort.php
+++ b/src/Link/Sort.php
@@ -15,13 +15,17 @@ trait Sort
     /**
      * Sort a Chain
      **
-     * @param int $sortFlags
+     * @param int|callable $options
      *
      * @return Chain
      */
-    public function sort($sortFlags = SORT_REGULAR)
+    public function sort($options = SORT_REGULAR)
     {
-        sort($this->array, $sortFlags);
+        if ($options && is_callable($options)) {
+            usort($this->array, $options);
+        } else {
+            sort($this->array, $options);
+        }
 
         return $this;
     }

--- a/src/Link/SortKeys.php
+++ b/src/Link/SortKeys.php
@@ -9,24 +9,39 @@ use Cocur\Chain\Chain;
  *
  * @package     Cocur\Chain\Link
  * @author      Christoph Rosse
+ * @author      Florian Eckerstorfer <florian@eckerstorfer.co>
  */
 trait SortKeys
 {
     /**
      * Sort a Chain by its keys.
      **
-     * @param int|callable $options
+     * @param int|callable $sortBy
+     * @param array        $options
      *
      * @return Chain
      */
-    public function sortKeys($options = SORT_REGULAR)
+    public function sortKeys($sortBy = SORT_REGULAR, array $options = [])
     {
-        if ($options && is_callable($options)) {
-            uksort($this->array, $options);
+        if ($sortBy && is_callable($sortBy)) {
+            uksort($this->array, $sortBy);
         } else {
-            ksort($this->array, $options);
+            $this->sortKeysWithFlags($sortBy, $options);
         }
 
         return $this;
+    }
+
+    /**
+     * @param int   $sortFlags
+     * @param array $options
+     */
+    private function sortKeysWithFlags($sortFlags = SORT_REGULAR, array $options = [])
+    {
+        if (!empty($options['reverse'])) {
+            krsort($this->array, $sortFlags);
+        } else {
+            ksort($this->array, $sortFlags);
+        }
     }
 }

--- a/src/Link/SortKeys.php
+++ b/src/Link/SortKeys.php
@@ -15,13 +15,17 @@ trait SortKeys
     /**
      * Sort a Chain by its keys.
      **
-     * @param int $sortFlags
+     * @param int|callable $options
      *
      * @return Chain
      */
-    public function sortKeys($sortFlags = SORT_REGULAR)
+    public function sortKeys($options = SORT_REGULAR)
     {
-        ksort($this->array, $sortFlags);
+        if ($options && is_callable($options)) {
+            uksort($this->array, $options);
+        } else {
+            ksort($this->array, $options);
+        }
 
         return $this;
     }

--- a/tests/Link/SortKeysTest.php
+++ b/tests/Link/SortKeysTest.php
@@ -23,7 +23,7 @@ class SortKeysTest extends PHPUnit_Framework_TestCase
         $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
         $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
 
-        $this->assertEquals(['apple' => 4, 'banana' => 3, 'lemon' => 1, 'orange' => 2], $mock->sortKeys()->array);
+        $this->assertSame(['apple' => 4, 'banana' => 3, 'lemon' => 1, 'orange' => 2], $mock->sortKeys()->array);
     }
 
     /**
@@ -36,6 +36,25 @@ class SortKeysTest extends PHPUnit_Framework_TestCase
         $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
         $mock->array = ['111' => 1, '21' => 2, '112' => 3, '22' => 4];
 
-        $this->assertEquals(['21' => 2, '22' => 4, '111' => 1, '112' => 3], $mock->sortKeys()->array);
+        $this->assertSame(['21' => 2, '22' => 4, '111' => 1, '112' => 3], $mock->sortKeys()->array);
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\SortKeys::sortKeys()
+     */
+    public function sortKeysWithFunction()
+    {
+        /** @var \Cocur\Chain\Link\SortKeys $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        $mock->array = ['kiwi' => 2, 'banana' => 3, 'apple' => 4];
+
+        // sort by strlen
+        $this->assertSame(['kiwi' => 2, 'apple' => 4, 'banana' => 3], $mock->sortKeys(function ($a, $b) {
+            $a = strlen($a);
+            $b = strlen($b);
+
+            return $a === $b ? 0 : ($a < $b ? -1 : 1);
+        })->array);
     }
 }

--- a/tests/Link/SortKeysTest.php
+++ b/tests/Link/SortKeysTest.php
@@ -9,6 +9,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @package   Cocur\Chain\Link
  * @author    Christoph Rosse
+ * @author    Florian Eckerstorfer <florian@eckerstorfer.co>
  * @group     unit
  */
 class SortKeysTest extends PHPUnit_Framework_TestCase
@@ -16,6 +17,7 @@ class SortKeysTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
+     * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
      */
     public function sortKeysWithDefaultSorting()
     {
@@ -29,6 +31,7 @@ class SortKeysTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
+     * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
      */
     public function sortKeysWithAlternativeSortingAlgorithm()
     {
@@ -37,6 +40,23 @@ class SortKeysTest extends PHPUnit_Framework_TestCase
         $mock->array = ['111' => 1, '21' => 2, '112' => 3, '22' => 4];
 
         $this->assertSame(['21' => 2, '22' => 4, '111' => 1, '112' => 3], $mock->sortKeys()->array);
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\SortKeys::sortKeys()
+     * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
+     */
+    public function sortKeysWithDefaultSortingAndReverseOption()
+    {
+        /** @var \Cocur\Chain\Link\SortKeys $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
+
+        $this->assertSame(
+            ['orange' => 2, 'lemon' => 1, 'banana' => 3, 'apple' => 4],
+            $mock->sortKeys(null, ['reverse' => true])->array
+        );
     }
 
     /**

--- a/tests/Link/SortTest.php
+++ b/tests/Link/SortTest.php
@@ -23,7 +23,7 @@ class SortTest extends PHPUnit_Framework_TestCase
         $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->assertEquals(['apple', 'banana', 'lemon', 'orange'], $mock->sort()->array);
+        $this->assertSame(['apple', 'banana', 'lemon', 'orange'], $mock->sort()->array);
     }
 
     /**
@@ -36,6 +36,25 @@ class SortTest extends PHPUnit_Framework_TestCase
         $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
         $mock->array = ['111', '21', '112', '22'];
 
-        $this->assertEquals(['21', '22', '111', '112'], $mock->sort(SORT_NUMERIC)->array);
+        $this->assertSame(['21', '22', '111', '112'], $mock->sort(SORT_NUMERIC)->array);
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Sort::sort()
+     */
+    public function sortWithFunction()
+    {
+        /** @var \Cocur\Chain\Link\Sort $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        $mock->array = ['kiwi', 'banana', 'apple'];
+
+        // sort by strlen
+        $this->assertSame(['kiwi', 'apple', 'banana'], $mock->sort(function ($a, $b) {
+            $a = strlen($a);
+            $b = strlen($b);
+
+            return $a === $b ? 0 : ($a < $b ? -1 : 1);
+        })->array);
     }
 }

--- a/tests/Link/SortTest.php
+++ b/tests/Link/SortTest.php
@@ -9,6 +9,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @package   Cocur\Chain\Link
  * @author    Christoph Rosse
+ * @author    Florian Eckerstorfer <florian@eckerstorfer.co>
  * @group     unit
  */
 class SortTest extends PHPUnit_Framework_TestCase
@@ -16,6 +17,7 @@ class SortTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
     public function sortWithDefaultSorting()
     {
@@ -29,6 +31,7 @@ class SortTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
     public function sortWithAlternativeSortingAlgorithm()
     {
@@ -42,6 +45,58 @@ class SortTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithFlags()
+     */
+    public function sortWithDefaultSortingAndAssocOption()
+    {
+        /** @var \Cocur\Chain\Link\Sort $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        $mock->array = ['lemon', 'orange', 'banana', 'apple'];
+
+        $this->assertSame(
+            [3 => 'apple', 2 => 'banana', 0 => 'lemon', 1 => 'orange'],
+            $mock->sort(null, ['assoc' => true])->array
+        );
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithFlags()
+     */
+    public function sortWithDefaultSortingAndReverseOption()
+    {
+        /** @var \Cocur\Chain\Link\Sort $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        $mock->array = ['lemon', 'orange', 'banana', 'apple'];
+
+        $this->assertSame(
+            ['orange', 'lemon', 'banana', 'apple'],
+            $mock->sort(null, ['reverse' => true])->array
+        );
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithFlags()
+     */
+    public function sortWithDefaultSortingAndAssocAndReverseOption()
+    {
+        /** @var \Cocur\Chain\Link\Sort $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        $mock->array = ['lemon', 'orange', 'banana', 'apple'];
+
+        $this->assertSame(
+            [1 => 'orange', 0 => 'lemon', 2 => 'banana', 3 => 'apple'],
+            $mock->sort(null, ['assoc' => true, 'reverse' => true])->array
+        );
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithCallback()
      */
     public function sortWithFunction()
     {
@@ -56,5 +111,25 @@ class SortTest extends PHPUnit_Framework_TestCase
 
             return $a === $b ? 0 : ($a < $b ? -1 : 1);
         })->array);
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Sort::sort()
+     * @covers Cocur\Chain\Link\Sort::sortWithCallback()
+     */
+    public function sortWithFunctionAndAssocOption()
+    {
+        /** @var \Cocur\Chain\Link\Sort $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        $mock->array = ['kiwi', 'banana', 'apple'];
+
+        // sort by strlen
+        $this->assertSame([0 => 'kiwi', 2 => 'apple', 1 => 'banana'], $mock->sort(function ($a, $b) {
+            $a = strlen($a);
+            $b = strlen($b);
+
+            return $a === $b ? 0 : ($a < $b ? -1 : 1);
+        }, ['assoc' => true])->array);
     }
 }


### PR DESCRIPTION
Assoc and reverse sort have been implemented as options for the `Sort` and `SortKeys` trait. The `assoc` option is only available in the `Sort` trait, `reverse` in both.