### PR TITLE
Add AbstractChain

### DIFF
--- a/src/AbstractChain.php
+++ b/src/AbstractChain.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Cocur\Chain;
 use ArrayAccess;
 use ArrayIterator;

--- a/src/AbstractChain.php
+++ b/src/AbstractChain.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Cocur\Chain;
+
 use ArrayAccess;
 use ArrayIterator;
 use IteratorAggregate;

--- a/src/AbstractChain.php
+++ b/src/AbstractChain.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Cocur\Chain;
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+
+/**
+ * Chain.
+ *
+ * @author    Florian Eckerstorfer
+ * @copyright 2015 Florian Eckerstorfer
+ */
+abstract class AbstractChain implements ArrayAccess, IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    public $array = [];
+
+    /**
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->array);
+    }
+
+    /**
+     * @param mixed $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->array[$offset]);
+    }
+
+    /**
+     * @param mixed $offset
+     *
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->array[$offset] = $value;
+    }
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+}

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain;
 
-use ArrayAccess;
-use ArrayIterator;
 use Cocur\Chain\Link\ChangeKeyCase;
 use Cocur\Chain\Link\Combine;
 use Cocur\Chain\Link\Count;
@@ -34,7 +32,6 @@ use Cocur\Chain\Link\SortKeys;
 use Cocur\Chain\Link\Sum;
 use Cocur\Chain\Link\Unique;
 use Cocur\Chain\Link\Unshift;
-use IteratorAggregate;
 
 /**
  * Chain.

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -42,7 +42,7 @@ use IteratorAggregate;
  * @author    Florian Eckerstorfer
  * @copyright 2015 Florian Eckerstorfer
  */
-class Chain implements ArrayAccess, IteratorAggregate
+class Chain extends AbstractChain
 {
     use ChangeKeyCase,
         Combine,
@@ -76,11 +76,6 @@ class Chain implements ArrayAccess, IteratorAggregate
         Unshift;
 
     /**
-     * @var array
-     */
-    public $array = [];
-
-    /**
      * @param array $array
      *
      * @return Chain
@@ -91,50 +86,5 @@ class Chain implements ArrayAccess, IteratorAggregate
         $chain->array = $array;
 
         return $chain;
-    }
-
-    /**
-     * @return ArrayIterator
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->array);
-    }
-
-    /**
-     * @param mixed $offset
-     *
-     * @return bool
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->array[$offset]);
-    }
-
-    /**
-     * @param mixed $offset
-     *
-     * @return mixed
-     */
-    public function offsetGet($offset)
-    {
-        return $this->array[$offset];
-    }
-
-    /**
-     * @param mixed $offset
-     * @param mixed $value
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->array[$offset] = $value;
-    }
-
-    /**
-     * @param mixed $offset
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->array[$offset]);
     }
 }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -63,7 +63,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Cocur\Chain\Chain::getIterator()
+     * @covers Cocur\Chain\AbstractChain::getIterator()
      */
     public function chainIsTraversable()
     {
@@ -79,10 +79,10 @@ class ChainTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Cocur\Chain\Chain::offsetExists()
-     * @covers Cocur\Chain\Chain::offsetGet()
-     * @covers Cocur\Chain\Chain::offsetSet()
-     * @covers Cocur\Chain\Chain::offsetUnset()
+     * @covers Cocur\Chain\AbstractChain::offsetExists()
+     * @covers Cocur\Chain\AbstractChain::offsetGet()
+     * @covers Cocur\Chain\AbstractChain::offsetSet()
+     * @covers Cocur\Chain\AbstractChain::offsetUnset()
      */
     public function chainAllowsArrayAccess()
     {


### PR DESCRIPTION
The data array and the basic iterator and array access methods are now in an abstract method. This allows developers to subclass `AbstractChain` and use only the traits they want. Developers can therefore create there own custom *version* of Chain.