### PR TITLE
Add method to create Chain from string

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -84,4 +84,26 @@ class Chain extends AbstractChain
 
         return $chain;
     }
+    
+    /**
+     * @param string $delimiter If the option `regexp` is `true` this must be a regular expression
+     * @param string $string
+     * @param array  $options   If the option `regexp` is `true` the string is split by using `preg_split()`, otherwise
+     *                          `explode()` is used.
+     *
+     * @return Chain
+     */
+    public static function createFromString($delimiter, $string, array $options = [])
+    {
+        $options = array_merge(['regexp' => false], $options);
+        $chain   = new static();
+
+        if ($options['regexp']) {
+            $chain->array = preg_split($delimiter, $string);
+        } else {
+            $chain->array = explode($delimiter, $string);
+        }
+
+        return $chain;
+    }
 }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -84,7 +84,7 @@ class Chain extends AbstractChain
 
         return $chain;
     }
-    
+
     /**
      * @param string $delimiter If the option `regexp` is `true` this must be a regular expression
      * @param string $string

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -113,6 +113,4 @@ class ChainTest extends PHPUnit_Framework_TestCase
         unset($c[0]);
         $this->assertFalse(isset($c[0]));
     }
-
-
 }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -24,6 +24,24 @@ class ChainTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers Cocur\Chain\Chain::createFromString()
+     */
+    public function createCreatesChainBySplittingStringWithDelimiter()
+    {
+        $this->assertEquals([1, 2, 3], Chain::createFromString(',', '1,2,3')->array);
+    }
+
+    /**
+     * @test
+     * @covers Cocur\Chain\Chain::createFromString()
+     */
+    public function createCreatesChainBySplittingStringWithRegExp()
+    {
+        $this->assertEquals([1, 2, 3, 4], Chain::createFromString('/[a-z]/', '1a2b3c4', ['regexp' => true])->array);
+    }
+
+    /**
+     * @test
      */
     public function chainHasTraits()
     {
@@ -95,4 +113,6 @@ class ChainTest extends PHPUnit_Framework_TestCase
         unset($c[0]);
         $this->assertFalse(isset($c[0]));
     }
+
+
 }


### PR DESCRIPTION
`Chain::createFromString()` allows to create a chain by splitting a given string either using a delimiter (`explode()`) or by providing a regular expression (`preg_split()`).