### PR TITLE
Restore constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ echo array_sum(array_intersect(
 What about this?
 
 ```php
-echo (new Chain([1, 2, 3, 4, 5]))
+echo Chain::create([1, 2, 3, 4, 5])
     ->diff([0, 1, 9])
-    ->intersect((new Chain([2, 3, 4]))->filter(function ($v) { return !($v & 1); }))
+    ->intersect(Chain::create([2, 3, 4])->filter(function ($v) { return !($v & 1); }))
     ->sum();
 ```
 
@@ -82,7 +82,11 @@ You can create a Chain by passing an array to the constructor.
 ```php
 $chain = new Chain([1, 2, 3]);
 ```
+Or with a convenient static method:
 
+```php
+$chain = Chain::create([1, 2, 3]);
+```
 In addition a Chain can also be created by the static `fill()` method, which is a wrapper for the `array_fill()`
 function.
 

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -79,15 +79,20 @@ class Chain extends AbstractChain implements Countable
 
     /**
      * @param array $array
+     */
+    public function __construct(array $array = [])
+    {
+        $this->array = $array;
+    }
+
+    /**
+     * @param array $array
      *
      * @return Chain
      */
     public static function create(array $array = [])
     {
-        $chain        = new static();
-        $chain->array = $array;
-
-        return $chain;
+        return new static($array);
     }
 
     /**

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -15,6 +15,15 @@ class ChainTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test
+     * @covers Cocur\Chain\Chain::__construct()
+     */
+    public function constructorCreatesChain()
+    {
+        $this->assertEquals([1, 2, 3], (new Chain([1, 2, 3]))->array);
+    }
+
+    /**
+     * @test
      * @covers Cocur\Chain\Chain::create()
      */
     public function createCreatesChain()


### PR DESCRIPTION
Missing constructor breaks all examples, including those published elsewhere.

Also, if we do all construction-related tasks in a constructor, everything is clearer.