### PR TITLE
Add Join link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ $chain->reduce(function ($current, $value) {
 - `->count()`
 - `->countValues()`
 - `->first()`
+- `->join([$glue])`
 - `->last()`
 - `->reduce()`
 - `->sum()`

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -14,6 +14,7 @@ use Cocur\Chain\Link\Flip;
 use Cocur\Chain\Link\Intersect;
 use Cocur\Chain\Link\IntersectAssoc;
 use Cocur\Chain\Link\IntersectKey;
+use Cocur\Chain\Link\Join;
 use Cocur\Chain\Link\Keys;
 use Cocur\Chain\Link\Last;
 use Cocur\Chain\Link\Map;
@@ -41,7 +42,7 @@ use Countable;
  * Chain.
  *
  * @author    Florian Eckerstorfer
- * @copyright 2015 Florian Eckerstorfer
+ * @copyright 2015-2017 Florian Eckerstorfer
  */
 class Chain extends AbstractChain implements Countable
 {
@@ -57,6 +58,7 @@ class Chain extends AbstractChain implements Countable
         Intersect,
         IntersectAssoc,
         IntersectKey,
+        Join,
         Keys,
         Last,
         Map,

--- a/src/Link/Join.php
+++ b/src/Link/Join.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Cocur\Chain\Link;
+
+/**
+ * Implode.
+ *
+ * @author    Florian Eckerstorfer
+ * @copyright 2017 Florian Eckerstorfer
+ */
+trait Join
+{
+    /**
+     * Join array elements with a string
+     *
+     * @param string $glue
+     *
+     * @return string Returns a string containing a string representation of all the array elements in the same order,
+     *                with the glue string between each element.
+     */
+    public function join($glue = '')
+    {
+        return implode($glue, $this->array);
+    }
+}

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -68,6 +68,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(method_exists($c, 'intersect'));
         $this->assertTrue(method_exists($c, 'intersectAssoc'));
         $this->assertTrue(method_exists($c, 'intersectKey'));
+        $this->assertTrue(method_exists($c, 'join'));
         $this->assertTrue(method_exists($c, 'keys'));
         $this->assertTrue(method_exists($c, 'last'));
         $this->assertTrue(method_exists($c, 'map'));

--- a/tests/Link/JoinTest.php
+++ b/tests/Link/JoinTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cocur\Chain\Link;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * CountTest.
+ *
+ * @author    Florian Eckerstorfer
+ * @copyright 2015 Florian Eckerstorfer
+ * @group     unit
+ */
+class JoinTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @covers Cocur\Chain\Link\Join::join()
+     */
+    public function joinReturnsStringWithoutGlue()
+    {
+        /** @var \Cocur\Chain\Link\Join $mock */
+        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Join');
+        $mock->array = ['a', 'b', 'c'];
+
+        $this->assertEquals('abc', $mock->join());
+    }
+}


### PR DESCRIPTION
Adds a new `Join` link which implements the `->join([$glue])` method, which corresponds to `join()` and `implode()` from PHP.