### PR TITLE
Refactor to support strong typing.

### DIFF
--- a/src/AbstractChain.php
+++ b/src/AbstractChain.php
@@ -23,7 +23,7 @@ abstract class AbstractChain implements ArrayAccess, IteratorAggregate, JsonSeri
     /**
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->array);
     }
@@ -33,7 +33,7 @@ abstract class AbstractChain implements ArrayAccess, IteratorAggregate, JsonSeri
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->array[$offset]);
     }
@@ -52,7 +52,7 @@ abstract class AbstractChain implements ArrayAccess, IteratorAggregate, JsonSeri
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->array[$offset] = $value;
     }
@@ -60,7 +60,7 @@ abstract class AbstractChain implements ArrayAccess, IteratorAggregate, JsonSeri
     /**
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->array[$offset]);
     }
@@ -68,7 +68,7 @@ abstract class AbstractChain implements ArrayAccess, IteratorAggregate, JsonSeri
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->array;
     }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -104,7 +104,7 @@ class Chain extends AbstractChain implements Countable
      *
      * @return Chain
      */
-    public static function create(array $array = [])
+    public static function create(array $array = []): Chain
     {
         return new static($array);
     }
@@ -117,7 +117,7 @@ class Chain extends AbstractChain implements Countable
      *
      * @return Chain
      */
-    public static function createFromString($delimiter, $string, array $options = [])
+    public static function createFromString(string $delimiter, string $string, array $options = []): Chain
     {
         $options = array_merge(['regexp' => false], $options);
         $chain   = new static();

--- a/src/Link/ChangeKeyCase.php
+++ b/src/Link/ChangeKeyCase.php
@@ -20,7 +20,7 @@ trait ChangeKeyCase
      *
      * @return Chain
      */
-    public function changeKeyCase($case = CASE_LOWER)
+    public function changeKeyCase(int $case = CASE_LOWER): Chain
     {
         $this->array = array_change_key_case($this->array, $case);
 

--- a/src/Link/Combine.php
+++ b/src/Link/Combine.php
@@ -20,7 +20,7 @@ trait Combine
      *
      * @return Chain
      */
-    public function combine($keys, $values)
+    public function combine($keys, $values): Chain
     {
         $this->array = array_combine(
             $keys instanceof Chain ? $keys->array : $keys,

--- a/src/Link/Count.php
+++ b/src/Link/Count.php
@@ -15,7 +15,7 @@ trait Count
      *
      * @return int Returns the number of elements in the array.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->array);
     }

--- a/src/Link/CountValues.php
+++ b/src/Link/CountValues.php
@@ -17,7 +17,7 @@ trait CountValues
      *
      * @return array An associative array of values from the array as keys and their count value.
      */
-    public function countValues()
+    public function countValues(): array
     {
         return array_count_values($this->array);
     }

--- a/src/Link/Diff.php
+++ b/src/Link/Diff.php
@@ -22,7 +22,7 @@ trait Diff
      *
      * @return Chain
      */
-    public function diff($array2)
+    public function diff($array2): Chain
     {
         $this->array = array_diff(
             $this->array,

--- a/src/Link/Fill.php
+++ b/src/Link/Fill.php
@@ -25,7 +25,7 @@ trait Fill
      *
      * @return Chain
      */
-    public static function fill($startIndex, $num, $value = null)
+    public static function fill(int $startIndex, int $num, $value = null): Chain
     {
         return new self(array_fill($startIndex, $num, $value));
     }

--- a/src/Link/Filter.php
+++ b/src/Link/Filter.php
@@ -22,7 +22,7 @@ trait Filter
      *
      * @return Chain
      */
-    public function filter(callable $callback)
+    public function filter(callable $callback): Chain
     {
         $this->array = array_filter($this->array, $callback, ARRAY_FILTER_USE_BOTH);
 

--- a/src/Link/FlatMap.php
+++ b/src/Link/FlatMap.php
@@ -12,9 +12,11 @@ use Cocur\Chain\Chain;
 trait FlatMap
 {
     /**
+     * @param callable $callback
+     *
      * @return Chain
      */
-    public function flatMap(callable $callback)
+    public function flatMap(callable $callback): Chain
     {
         $flattened = [];
         foreach ($this->array as $index => $element) {

--- a/src/Link/Flip.php
+++ b/src/Link/Flip.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Flip.
  *
@@ -13,7 +15,7 @@ trait Flip
     /**
      * @return Chain
      */
-    public function flip()
+    public function flip(): Chain
     {
         $this->array = array_flip($this->array);
 

--- a/src/Link/Intersect.php
+++ b/src/Link/Intersect.php
@@ -17,7 +17,7 @@ trait Intersect
      *
      * @return Chain
      */
-    public function intersect($array2)
+    public function intersect($array2): Chain
     {
         $this->array = array_intersect($this->array, $array2 instanceof Chain ? $array2->array : $array2);
 

--- a/src/Link/IntersectAssoc.php
+++ b/src/Link/IntersectAssoc.php
@@ -17,7 +17,7 @@ trait IntersectAssoc
      *
      * @return Chain
      */
-    public function intersectAssoc($array)
+    public function intersectAssoc($array): Chain
     {
         $this->array = array_intersect_assoc($this->array, $array instanceof Chain ? $array->array : $array);
 

--- a/src/Link/IntersectKey.php
+++ b/src/Link/IntersectKey.php
@@ -17,7 +17,7 @@ trait IntersectKey
      *
      * @return Chain
      */
-    public function intersectKey($array)
+    public function intersectKey($array): Chain
     {
         $this->array = array_intersect_key($this->array, $array instanceof Chain ? $array->array : $array);
 

--- a/src/Link/Join.php
+++ b/src/Link/Join.php
@@ -18,7 +18,7 @@ trait Join
      * @return string Returns a string containing a string representation of all the array elements in the same order,
      *                with the glue string between each element.
      */
-    public function join($glue = '')
+    public function join(string $glue = ''): string
     {
         return implode($glue, $this->array);
     }

--- a/src/Link/KeyExists.php
+++ b/src/Link/KeyExists.php
@@ -20,7 +20,7 @@ trait KeyExists
      *
      * @return bool `true` if key or index exists in array, `false` otherwise.
      */
-    public function keyExists($key)
+    public function keyExists($key): bool
     {
         return array_key_exists($key, $this->array);
     }

--- a/src/Link/Keys.php
+++ b/src/Link/Keys.php
@@ -15,7 +15,7 @@ trait Keys
     /**
      * @return Chain
      */
-    public function keys()
+    public function keys(): Chain
     {
         $this->array = array_keys($this->array);
 

--- a/src/Link/Map.php
+++ b/src/Link/Map.php
@@ -17,7 +17,7 @@ trait Map
      *
      * @return Chain
      */
-    public function map(callable $callback)
+    public function map(callable $callback): Chain
     {
         foreach ($this->array as $index => $element) {
             $this->array[$index] = $callback($element, $index);

--- a/src/Link/Merge.php
+++ b/src/Link/Merge.php
@@ -22,7 +22,7 @@ trait Merge
      *
      * @return Chain
      */
-    public function merge($array, array $options = [])
+    public function merge($array, array $options = []): Chain
     {
         $options = array_merge(['recursive' => false], $options);
 

--- a/src/Link/Pad.php
+++ b/src/Link/Pad.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Pad.
  *
@@ -16,7 +18,7 @@ trait Pad
      *
      * @return Chain
      */
-    public function pad($size, $value)
+    public function pad(int $size, $value): Chain
     {
         $this->array = array_pad($this->array, $size, $value);
 

--- a/src/Link/Product.php
+++ b/src/Link/Product.php
@@ -11,7 +11,7 @@ namespace Cocur\Chain\Link;
 trait Product
 {
     /**
-     * @return number
+     * @return int|float
      */
     public function product()
     {

--- a/src/Link/Push.php
+++ b/src/Link/Push.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Push.
  *
@@ -15,7 +17,7 @@ trait Push
      *
      * @return Chain
      */
-    public function push($element)
+    public function push($element): Chain
     {
         array_push($this->array, $element);
 

--- a/src/Link/Rand.php
+++ b/src/Link/Rand.php
@@ -15,7 +15,7 @@ trait Rand
      *
      * @return mixed
      */
-    public function rand($num = 1)
+    public function rand(int $num = 1)
     {
         return array_rand($this->array, $num);
     }

--- a/src/Link/Replace.php
+++ b/src/Link/Replace.php
@@ -17,7 +17,7 @@ trait Replace
      *
      * @return Chain
      */
-    public function replace($array)
+    public function replace($array): Chain
     {
         $this->array = array_replace($this->array, $array instanceof Chain ? $chain->array : $array);
 

--- a/src/Link/Reverse.php
+++ b/src/Link/Reverse.php
@@ -17,7 +17,7 @@ trait Reverse
      *
      * @return Chain
      */
-    public function reverse($preserveKeys = false)
+    public function reverse(bool $preserveKeys = false): Chain
     {
         $this->array = array_reverse($this->array, $preserveKeys);
 

--- a/src/Link/Search.php
+++ b/src/Link/Search.php
@@ -16,7 +16,7 @@ trait Search
      *
      * @return mixed
      */
-    public function search($needle, $strict = false)
+    public function search($needle, bool $strict = false)
     {
         return array_search($needle, $this->array, $strict);
     }

--- a/src/Link/Shuffle.php
+++ b/src/Link/Shuffle.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Shuffle.
  *
@@ -13,7 +15,7 @@ trait Shuffle
     /**
      * @return Chain
      */
-    public function shuffle()
+    public function shuffle(): Chain
     {
         shuffle($this->array);
 

--- a/src/Link/Slice.php
+++ b/src/Link/Slice.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Slice.
  *
@@ -17,7 +19,7 @@ trait Slice
      *
      * @return Chain
      */
-    public function slice($offset, $length = null, $preserveKeys = false)
+    public function slice(int $offset, ?int $length = null, bool $preserveKeys = false): Chain
     {
         $this->array = array_slice($this->array, $offset, $length, $preserveKeys);
 

--- a/src/Link/Sort.php
+++ b/src/Link/Sort.php
@@ -20,7 +20,7 @@ trait Sort
      *
      * @return Chain
      */
-    public function sort($sortBy = SORT_REGULAR, array $options = [])
+    public function sort($sortBy = SORT_REGULAR, array $options = []): Chain
     {
         if (!$sortBy) {
             $sortBy = SORT_REGULAR;
@@ -38,7 +38,7 @@ trait Sort
      * @param callable $callback
      * @param array    $options
      */
-    private function sortWithCallback(callable $callback, array $options = [])
+    private function sortWithCallback(callable $callback, array $options = []): void
     {
         if (isset($options['assoc']) && $options['assoc']) {
             uasort($this->array, $callback);
@@ -51,7 +51,7 @@ trait Sort
      * @param int   $sortFlags
      * @param array $options
      */
-    private function sortWithFlags($sortFlags = SORT_REGULAR, array $options = [])
+    private function sortWithFlags(int $sortFlags = SORT_REGULAR, array $options = []): void
     {
         if (!empty($options['assoc']) && !empty($options['reverse'])) {
             arsort($this->array, $sortFlags);

--- a/src/Link/SortKeys.php
+++ b/src/Link/SortKeys.php
@@ -20,7 +20,7 @@ trait SortKeys
      *
      * @return Chain
      */
-    public function sortKeys($sortBy = SORT_REGULAR, array $options = [])
+    public function sortKeys($sortBy = SORT_REGULAR, array $options = []): Chain
     {
         if ($sortBy && is_callable($sortBy)) {
             uksort($this->array, $sortBy);
@@ -35,7 +35,7 @@ trait SortKeys
      * @param int   $sortFlags
      * @param array $options
      */
-    private function sortKeysWithFlags($sortFlags = SORT_REGULAR, array $options = [])
+    private function sortKeysWithFlags(int $sortFlags = SORT_REGULAR, array $options = []): void
     {
         if (!empty($options['reverse'])) {
             krsort($this->array, $sortFlags);

--- a/src/Link/Splice.php
+++ b/src/Link/Splice.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Splice.
  *
@@ -10,12 +12,23 @@ namespace Cocur\Chain\Link;
  */
 trait Splice
 {
-    public function splice($offset, $length = null, $replacement = [])
+    /**
+     * Remove a portion of the array and replace it with something else
+     *
+     * @param int $offset
+     * @param int|null $length
+     * @param array $replacement
+     *
+     * @return Chain
+     */
+    public function splice(int $offset, ?int $length = null, $replacement = []): Chain
     {
         if ($length) {
             array_splice($this->array, $offset, $length, $replacement);
         } else {
             array_splice($this->array, $offset);
         }
+
+        return $this;
     }
 }

--- a/src/Link/Sum.php
+++ b/src/Link/Sum.php
@@ -11,7 +11,7 @@ namespace Cocur\Chain\Link;
 trait Sum
 {
     /**
-     * @return number
+     * @return int|float
      */
     public function sum()
     {

--- a/src/Link/Unique.php
+++ b/src/Link/Unique.php
@@ -17,7 +17,7 @@ trait Unique
      *
      * @return Chain
      */
-    public function unique($sortFlags = SORT_STRING)
+    public function unique(int $sortFlags = SORT_STRING): Chain
     {
         $this->array = array_unique($this->array, $sortFlags);
 

--- a/src/Link/Unshift.php
+++ b/src/Link/Unshift.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * Unshift.
  *
@@ -15,7 +17,7 @@ trait Unshift
      *
      * @return Chain
      */
-    public function unshift($element)
+    public function unshift($element): Chain
     {
         array_unshift($this->array, $element);
 

--- a/src/Link/Values.php
+++ b/src/Link/Values.php
@@ -15,7 +15,7 @@ trait Values
     /**
      * @return Chain
      */
-    public function values()
+    public function values(): Chain
     {
         $this->array = array_values($this->array);
 

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain;
 
+use PHPUnit\Framework\MockObject\MockObject;
+
 /**
  * ChainTest.
  *
@@ -12,10 +14,27 @@ namespace Cocur\Chain;
 class ChainTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Generate the expected TypeError that will be emitted when mocking Trait using Fluent design.
+     * This serve two purposes:
+     * - swallow the error and keep the test passing
+     * - validate that the method is effectively fluent.
+     *
+     * @param MockObject $mockedTrait
+     * @return string
+     */
+    public static function getFluentTypeErrorForMockedTrait(MockObject $mockedTrait): string
+    {
+        $mockClass = get_class($mockedTrait);
+        $traitClass = substr($mockClass, 5, -9);
+        return sprintf('/Return value of %s::.*?\\(\\) must be an instance of %s, instance of %s returned/',
+            $traitClass, str_replace('\\', '\\\\', Chain::class), $mockClass);
+    }
+
+    /**
      * @test
      * @covers Cocur\Chain\Chain::__construct()
      */
-    public function constructorCreatesChain()
+    public function constructorCreatesChain(): void
     {
         $this->assertEquals([1, 2, 3], (new Chain([1, 2, 3]))->array);
     }
@@ -24,7 +43,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Chain::create()
      */
-    public function createCreatesChain()
+    public function createCreatesChain(): void
     {
         $this->assertEquals([1, 2, 3], Chain::create([1, 2, 3])->array);
     }
@@ -33,7 +52,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Chain::createFromString()
      */
-    public function createCreatesChainBySplittingStringWithDelimiter()
+    public function createCreatesChainBySplittingStringWithDelimiter(): void
     {
         $this->assertEquals([1, 2, 3], Chain::createFromString(',', '1,2,3')->array);
     }
@@ -42,7 +61,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Chain::createFromString()
      */
-    public function createCreatesChainBySplittingStringWithRegExp()
+    public function createCreatesChainBySplittingStringWithRegExp(): void
     {
         $this->assertEquals([1, 2, 3, 4], Chain::createFromString('/[a-z]/', '1a2b3c4', ['regexp' => true])->array);
     }
@@ -50,7 +69,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function chainHasTraits()
+    public function chainHasTraits(): void
     {
         $c = new Chain();
 
@@ -98,12 +117,12 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\AbstractChain::getIterator()
      */
-    public function chainIsTraversable()
+    public function chainIsTraversable(): void
     {
         $data = ['a', 'b'];
         $c    = Chain::create($data);
 
-        $this->assertInstanceOf('\Traversable', $c);
+        $this->assertInstanceOf(\Traversable::class, $c);
 
         foreach ($c as $key => $value) {
             $this->assertEquals($data[$key], $value);
@@ -117,7 +136,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\AbstractChain::offsetSet()
      * @covers Cocur\Chain\AbstractChain::offsetUnset()
      */
-    public function chainAllowsArrayAccess()
+    public function chainAllowsArrayAccess(): void
     {
         $c = Chain::create();
 
@@ -133,11 +152,11 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Chain::count()
      */
-    public function chainIsCountable()
+    public function chainIsCountable(): void
     {
         $c = Chain::create([0, 1, 2]);
 
-        $this->assertInstanceOf('\Countable', $c);
+        $this->assertInstanceOf(\Countable::class, $c);
         $this->assertEquals(3, count($c));
     }
 
@@ -145,11 +164,11 @@ class ChainTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Chain::jsonSerialize()
      */
-    public function chainIsJsonSerializable()
+    public function chainIsJsonSerializable(): void
     {
         $c = Chain::create([0, 1, 2]);
 
-        $this->assertInstanceOf('\JsonSerializable', $c);
+        $this->assertInstanceOf(\JsonSerializable::class, $c);
         $this->assertEquals('[0,1,2]', json_encode($c));
     }
 }

--- a/tests/Link/ChangeKeyCaseTest.php
+++ b/tests/Link/ChangeKeyCaseTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * CountTest.
  *
@@ -14,12 +16,14 @@ class ChangeKeyCaseTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\ChangeKeyCase::changeKeyCase()
      */
-    public function changeKeyCaseDefaultsToLower()
+    public function changeKeyCaseDefaultsToLower(): void
     {
-        /** @var \Cocur\Chain\Link\ChangeKeyCase $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\ChangeKeyCase');
+        $this->expectException(\TypeError::class);
+        /** @var ChangeKeyCase $mock */
+        $mock        = $this->getMockForTrait(ChangeKeyCase::class);
         $mock->array = ['FoO' => 1, 'BAR' => 2];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 1, 'bar' => 2], $mock->changeKeyCase()->array);
     }
 
@@ -27,12 +31,13 @@ class ChangeKeyCaseTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\ChangeKeyCase::changeKeyCase()
      */
-    public function changeKeyCaseUsesGivenCase()
+    public function changeKeyCaseUsesGivenCase(): void
     {
-        /** @var \Cocur\Chain\Link\ChangeKeyCase $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\ChangeKeyCase');
+        /** @var ChangeKeyCase $mock */
+        $mock        = $this->getMockForTrait(ChangeKeyCase::class);
         $mock->array = ['FoO' => 1, 'bar' => 2];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['FOO' => 1, 'BAR' => 2], $mock->changeKeyCase(CASE_UPPER)->array);
     }
 }

--- a/tests/Link/CombineTest.php
+++ b/tests/Link/CombineTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 
 /**
@@ -17,14 +18,15 @@ class CombineTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Combine::combine()
      */
-    public function combineValuesAndKeysWithChainTest()
+    public function combineValuesAndKeysWithChainTest(): void
     {
-        /** @var \Cocur\Chain\Link\Combine $mock */
-        $mock = $this->getMockForTrait('Cocur\Chain\Link\Combine');
+        /** @var Combine $mock */
+        $mock = $this->getMockForTrait(Combine::class);
 
         $keys   = Chain::create(['foo', 'bar']);
         $values = Chain::create([42, 43]);
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 42, 'bar' => 43], $mock->combine($keys, $values)->array);
     }
 
@@ -32,14 +34,15 @@ class CombineTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Combine::combine()
      */
-    public function combineValuesAndKeysWithArraysTest()
+    public function combineValuesAndKeysWithArraysTest(): void
     {
-        /** @var \Cocur\Chain\Link\Combine $mock */
-        $mock = $this->getMockForTrait('Cocur\Chain\Link\Combine');
+        /** @var Combine $mock */
+        $mock = $this->getMockForTrait(Combine::class);
 
         $keys   = ['foo', 'bar'];
         $values = [42, 43];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 42, 'bar' => 43], $mock->combine($keys, $values)->array);
     }
 }

--- a/tests/Link/CountTest.php
+++ b/tests/Link/CountTest.php
@@ -17,10 +17,10 @@ class CountTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Count::count()
      */
-    public function countReturnsNumberOfElements()
+    public function countReturnsNumberOfElements(): void
     {
-        /** @var \Cocur\Chain\Link\Count $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Count');
+        /** @var Count $mock */
+        $mock        = $this->getMockForTrait(Count::class);
         $mock->array = [0, 1, 2, 3];
 
         $this->assertEquals(4, $mock->count());

--- a/tests/Link/CountValuesTest.php
+++ b/tests/Link/CountValuesTest.php
@@ -15,10 +15,10 @@ class CountValuesTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\CountValues::countValues()
      */
-    public function countValuesReturnsValueCounts()
+    public function countValuesReturnsValueCounts(): void
     {
-        /** @var \Cocur\Chain\Link\CountValues $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\CountValues');
+        /** @var CountValues $mock */
+        $mock        = $this->getMockForTrait(CountValues::class);
         $mock->array = ['lemon', 'orange', 'lemon', 'apple', 'lemon'];
 
         $this->assertSame(['lemon' => 3, 'orange' => 1, 'apple' => 1], $mock->countValues());

--- a/tests/Link/DiffTest.php
+++ b/tests/Link/DiffTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 /**
  * DiffTest.
@@ -17,11 +18,12 @@ class DiffTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Diff::diff()
      */
-    public function diffDiffsChainWithArray()
+    public function diffDiffsChainWithArray(): void
     {
-        /** @var \Cocur\Chain\Link\Diff $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Diff');
+        /** @var Diff $mock */
+        $mock        = $this->getMockForTrait(Diff::class);
         $mock->array = [0, 1, 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->diff([1, 2, 3]);
 
         $this->assertEquals([0], $mock->array);
@@ -31,11 +33,12 @@ class DiffTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Diff::diff()
      */
-    public function diffDiffsChainWithChain()
+    public function diffDiffsChainWithChain(): void
     {
-        /** @var \Cocur\Chain\Link\Diff $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Diff');
+        /** @var Diff $mock */
+        $mock        = $this->getMockForTrait(Diff::class);
         $mock->array = [0, 1, 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->diff(Chain::create([1, 2, 3]));
 
         $this->assertEquals([0], $mock->array);

--- a/tests/Link/FillTest.php
+++ b/tests/Link/FillTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\Chain;
+
 /**
  * FillTest.
  *
@@ -15,8 +17,11 @@ class FillTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Fill::fill()
      */
-    public function fillCreatesAFilledChain()
+    public function fillCreatesAFilledChain(): void
     {
+        $fluentTypeErrorMessage = sprintf('Return value of %1$s::fill() must be an instance of %2$s, instance of %1$s returned',
+            ChainMock::class, Chain::class);
+        $this->expectExceptionMessage($fluentTypeErrorMessage);
         $mock = ChainMock::fill(0, 10);
 
         $this->assertIsArray($mock->array);

--- a/tests/Link/FilterTest.php
+++ b/tests/Link/FilterTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * FilterTest.
  *
@@ -15,12 +17,13 @@ class FilterTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Filter::filter()
      */
-    public function filterFiltersArray()
+    public function filterFiltersArray(): void
     {
-        /** @var \Cocur\Chain\Link\Filter $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Filter');
+        /** @var Filter $mock */
+        $mock        = $this->getMockForTrait(Filter::class);
         $mock->array = [0, 1, 2, 3];
-        $mock->filter(function ($v) { return $v & 1; });
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
+        $mock->filter(function ($v): bool { return $v & 1; });
 
         $this->assertCount(2, $mock->array);
         $this->assertContains(1, $mock->array);
@@ -33,12 +36,13 @@ class FilterTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Filter::filter()
      */
-    public function filterFiltersArrayByKey()
+    public function filterFiltersArrayByKey(): void
     {
-        /** @var \Cocur\Chain\Link\Filter $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Filter');
+        /** @var Filter $mock */
+        $mock        = $this->getMockForTrait(Filter::class);
         $mock->array = ["0" => 0, "1" => 1, "2" => 2, "3" => 3];
-        $mock->filter(function ($v, $k) { return intval($k) & 1; });
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
+        $mock->filter(function ($v, $k): bool { return intval($k) & 1; });
 
         $this->assertCount(2, $mock->array);
         $this->assertContains(1, $mock->array);

--- a/tests/Link/FindTest.php
+++ b/tests/Link/FindTest.php
@@ -16,13 +16,13 @@ class FindTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Find::find()
      */
-    public function findFindsAnElementByACallback()
+    public function findFindsAnElementByACallback(): void
     {
-        /** @var \Cocur\Chain\Link\Find $mock */
-        $mock = $this->getMockForTrait('Cocur\Chain\Link\Find');
+        /** @var Find $mock */
+        $mock = $this->getMockForTrait(Find::class);
         $mock->array = ['foo', 'bar', 'bar'];
 
-        $result = $mock->find(function ($item) { return $item === 'bar'; });
+        $result = $mock->find(function ($item): bool { return $item === 'bar'; });
         $this->assertEquals('bar', $result);
     }
 
@@ -30,13 +30,13 @@ class FindTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Find::find()
      */
-    public function findReturnsFalseIfElementCantBeFound()
+    public function findReturnsFalseIfElementCantBeFound(): void
     {
-        /** @var \Cocur\Chain\Link\Find $mock */
-        $mock = $this->getMockForTrait('Cocur\Chain\Link\Find');
+        /** @var Find $mock */
+        $mock = $this->getMockForTrait(Find::class);
         $mock->array = ['foo', 'bar', 'bar'];
 
-        $result = $mock->find(function ($item) { return $item === 'IDONTEXIST'; });
+        $result = $mock->find(function ($item): bool { return $item === 'IDONTEXIST'; });
         $this->assertFalse($result);
     }
 }

--- a/tests/Link/FirstTest.php
+++ b/tests/Link/FirstTest.php
@@ -17,10 +17,10 @@ class FirstTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\First::first()
      */
-    public function firstReturnsFirstElement()
+    public function firstReturnsFirstElement(): void
     {
-        /** @var \Cocur\Chain\Link\Filter $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\First');
+        /** @var First $mock */
+        $mock        = $this->getMockForTrait(First::class);
         $mock->array = [0, 1, 2, 3];
 
         $this->assertEquals(0, $mock->first());

--- a/tests/Link/FlatMapTest.php
+++ b/tests/Link/FlatMapTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * MapTest.
  *
@@ -14,11 +16,12 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\FlatMap::flatMap()
      */
-    public function flatMapAppliesMapToArray()
+    public function flatMapAppliesMapToArray(): void
     {
-        /** @var \Cocur\Chain\Link\FlatMap $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\FlatMap');
+        /** @var FlatMap $mock */
+        $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['foobar', 'bar'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v) { return [str_replace('bar', 'foo', $v)]; });
 
         $this->assertEquals('foofoo', $mock->array[0]);
@@ -29,11 +32,12 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\FlatMap::flatMap()
      */
-    public function flatMapCallbackReceivesAlsoArrayKeys()
+    public function flatMapCallbackReceivesAlsoArrayKeys(): void
     {
-        /** @var \Cocur\Chain\Link\FlatMap $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\FlatMap');
+        /** @var FlatMap $mock */
+        $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['foo' => 'fizz', 'bar' => 'buzz'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v, $k) {
             return $k == 'foo' ? [str_replace('fizz', 'bang', $v)] : [$v];
         });
@@ -45,11 +49,12 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\FlatMap::flatMap()
      */
-    public function flatMapCallbackCanReturnScalarOrArray()
+    public function flatMapCallbackCanReturnScalarOrArray(): void
     {
-        /** @var \Cocur\Chain\Link\FlatMap $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\FlatMap');
+        /** @var FlatMap $mock */
+        $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['fizz', 'buzz'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v, $k) {
             return $k == 1 ? [$v] : $v;
         });
@@ -61,11 +66,12 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\FlatMap::flatMap()
      */
-    public function flatMapAcceptsEmptyArray()
+    public function flatMapAcceptsEmptyArray(): void
     {
-        /** @var \Cocur\Chain\Link\FlatMap $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\FlatMap');
+        /** @var FlatMap $mock */
+        $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = [];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v) {
             return $v;
         });

--- a/tests/Link/FlipTest.php
+++ b/tests/Link/FlipTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * FlipTest.
  *
@@ -15,11 +17,12 @@ class FlipTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Flip::flip()
      */
-    public function flipExchangesKeysAndValues()
+    public function flipExchangesKeysAndValues(): void
     {
-        /** @var \Cocur\Chain\Link\Flip $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Flip');
+        /** @var Flip $mock */
+        $mock        = $this->getMockForTrait(Flip::class);
         $mock->array = ['foo', 'bar'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flip();
 
         $this->assertEquals(['foo' => 0, 'bar' => 1], $mock->array);

--- a/tests/Link/IntersectAssocTest.php
+++ b/tests/Link/IntersectAssocTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 /**
  * IntersectAssocTest.
@@ -17,11 +18,12 @@ class IntersectAssocTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\IntersectAssoc::intersectAssoc()
      */
-    public function intersectAssocIntersectsWithArray()
+    public function intersectAssocIntersectsWithArray(): void
     {
-        /** @var \Cocur\Chain\Link\IntersectAssoc $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\IntersectAssoc');
+        /** @var IntersectAssoc $mock */
+        $mock        = $this->getMockForTrait(IntersectAssoc::class);
         $mock->array = [1, 2, 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectAssoc([3, 2, 1]);
 
         $this->assertContains(2, $mock->array);
@@ -33,11 +35,12 @@ class IntersectAssocTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\IntersectAssoc::intersectAssoc()
      */
-    public function intersectAssocIntersectsWithChain()
+    public function intersectAssocIntersectsWithChain(): void
     {
-        /** @var \Cocur\Chain\Link\IntersectAssoc $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\IntersectAssoc');
+        /** @var IntersectAssoc $mock */
+        $mock        = $this->getMockForTrait(IntersectAssoc::class);
         $mock->array = [1, 2, 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectAssoc(Chain::create([3, 2, 1]));
 
         $this->assertContains(2, $mock->array);

--- a/tests/Link/IntersectKeyTest.php
+++ b/tests/Link/IntersectKeyTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 /**
  * IntersectKeyTest.
@@ -17,11 +18,12 @@ class IntersectKeyTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\IntersectKey::intersectKey()
      */
-    public function intersectKeyIntersectsWithArray()
+    public function intersectKeyIntersectsWithArray(): void
     {
-        /** @var \Cocur\Chain\Link\IntersectKey $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\IntersectKey');
+        /** @var IntersectKey $mock */
+        $mock        = $this->getMockForTrait(IntersectKey::class);
         $mock->array = ['a' => 1, 'b' => 2, 'c' => 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectKey(['a' => 3, 'b' => 4, 'd' => 5]);
 
         $this->assertEquals(['a' => 1, 'b' => 2], $mock->array);
@@ -31,11 +33,12 @@ class IntersectKeyTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\IntersectKey::intersectKey()
      */
-    public function intersectKeyIntersectsWithChain()
+    public function intersectKeyIntersectsWithChain(): void
     {
-        /** @var \Cocur\Chain\Link\IntersectKey $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\IntersectKey');
+        /** @var IntersectKey $mock */
+        $mock        = $this->getMockForTrait(IntersectKey::class);
         $mock->array = ['a' => 1, 'b' => 2, 'c' => 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectKey(Chain::create(['a' => 3, 'b' => 4, 'd' => 5]));
 
         $this->assertEquals(['a' => 1, 'b' => 2], $mock->array);

--- a/tests/Link/IntersectTest.php
+++ b/tests/Link/IntersectTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 /**
  * IntersectTest.
@@ -16,11 +17,12 @@ class IntersectTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Intersect::intersect()
      */
-    public function intersectIntersectsWithArray()
+    public function intersectIntersectsWithArray(): void
     {
-        /** @var \Cocur\Chain\Link\Intersect $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Intersect');
+        /** @var Intersect $mock */
+        $mock        = $this->getMockForTrait(Intersect::class);
         $mock->array = [1, 2, 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersect([3, 4, 5]);
 
         $this->assertContains(3, $mock->array);
@@ -32,11 +34,12 @@ class IntersectTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Intersect::intersect()
      */
-    public function intersectIntersectsWithChain()
+    public function intersectIntersectsWithChain(): void
     {
-        /** @var \Cocur\Chain\Link\Intersect $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Intersect');
+        /** @var Intersect $mock */
+        $mock        = $this->getMockForTrait(Intersect::class);
         $mock->array = [1, 2, 3];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersect(Chain::create([3, 4, 5]));
 
         $this->assertContains(3, $mock->array);

--- a/tests/Link/JoinTest.php
+++ b/tests/Link/JoinTest.php
@@ -15,10 +15,10 @@ class JoinTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Join::join()
      */
-    public function joinReturnsStringWithoutGlue()
+    public function joinReturnsStringWithoutGlue(): void
     {
-        /** @var \Cocur\Chain\Link\Join $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Join');
+        /** @var Join $mock */
+        $mock        = $this->getMockForTrait(Join::class);
         $mock->array = ['a', 'b', 'c'];
 
         $this->assertEquals('abc', $mock->join());

--- a/tests/Link/KeyExistsTest.php
+++ b/tests/Link/KeyExistsTest.php
@@ -15,10 +15,10 @@ class KeyExistsTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\KeyExists::keyExists()
      */
-    public function keyExistsReturnsTrueIfKeyExists()
+    public function keyExistsReturnsTrueIfKeyExists(): void
     {
-        /** @var \Cocur\Chain\Link\KeyExists $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\KeyExists');
+        /** @var KeyExists $mock */
+        $mock        = $this->getMockForTrait(KeyExists::class);
         $mock->array = ['foo' => 1, 'bar' => null];
 
         $this->assertTrue($mock->keyExists('foo'));
@@ -29,10 +29,10 @@ class KeyExistsTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\KeyExists::keyExists()
      */
-    public function keyExistsReturnsFalseIfKeyDoesNotExist()
+    public function keyExistsReturnsFalseIfKeyDoesNotExist(): void
     {
-        /** @var \Cocur\Chain\Link\KeyExists $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\KeyExists');
+        /** @var KeyExists $mock */
+        $mock        = $this->getMockForTrait(KeyExists::class);
         $mock->array = [];
 
         $this->assertFalse($mock->keyExists('invalid'));

--- a/tests/Link/KeysTest.php
+++ b/tests/Link/KeysTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * KeysTest.
  *
@@ -15,11 +17,12 @@ class KeysTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Keys::keys()
      */
-    public function keysChangesArrayToKeys()
+    public function keysChangesArrayToKeys(): void
     {
-        /** @var \Cocur\Chain\Link\Keys $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Keys');
+        /** @var Keys $mock */
+        $mock        = $this->getMockForTrait(Keys::class);
         $mock->array = ['foo' => 1, 'bar' => 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->keys();
 
         $this->assertEquals(['foo', 'bar'], $mock->array);

--- a/tests/Link/LastTest.php
+++ b/tests/Link/LastTest.php
@@ -15,10 +15,10 @@ class LastTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Last::last()
      */
-    public function lastReturnsLastElement()
+    public function lastReturnsLastElement(): void
     {
-        /** @var \Cocur\Chain\Link\Filter $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Last');
+        /** @var Last $mock */
+        $mock        = $this->getMockForTrait(Last::class);
         $mock->array = [0, 1, 2, 3];
 
         $this->assertEquals(3, $mock->last());

--- a/tests/Link/MapTest.php
+++ b/tests/Link/MapTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * MapTest.
  *
@@ -15,11 +17,12 @@ class MapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Map::map()
      */
-    public function mapAppliesMapToArray()
+    public function mapAppliesMapToArray(): void
     {
-        /** @var \Cocur\Chain\Link\Map $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Map');
+        /** @var Map $mock */
+        $mock        = $this->getMockForTrait(Map::class);
         $mock->array = ['foobar', 'bar'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->map(function ($v) { return str_replace('bar', 'foo', $v); });
 
         $this->assertEquals('foofoo', $mock->array[0]);
@@ -30,11 +33,12 @@ class MapTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Map::map()
      */
-    public function mapCallbackReceivesAlsoArrayKeys()
+    public function mapCallbackReceivesAlsoArrayKeys(): void
     {
-        /** @var \Cocur\Chain\Link\Map $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Map');
+        /** @var Map $mock */
+        $mock        = $this->getMockForTrait(Map::class);
         $mock->array = ['foo' => 'fizz', 'bar' => 'buzz'];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->map(function ($v, $k) {
             return $k == 'foo' ? str_replace('fizz', 'bang', $v) : $v;
         });

--- a/tests/Link/MergeTest.php
+++ b/tests/Link/MergeTest.php
@@ -3,6 +3,7 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
+use Cocur\Chain\ChainTest;
 
 /**
  * MergeTest.
@@ -16,11 +17,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Merge::merge()
      */
-    public function mergeMergesArray()
+    public function mergeMergesArray(): void
     {
-        /** @var \Cocur\Chain\Link\Merge $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Merge');
+        /** @var Merge $mock */
+        $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = [0, 1, 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge([3, 4]);
 
         $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
@@ -30,11 +32,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Merge::merge()
      */
-    public function mergeMergesChain()
+    public function mergeMergesChain(): void
     {
-        /** @var \Cocur\Chain\Link\Merge $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Merge');
+        /** @var Merge $mock */
+        $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = [0, 1, 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(Chain::create([3, 4]));
 
         $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
@@ -44,11 +47,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Merge::merge()
      */
-    public function mergeMergesRecursiveArray()
+    public function mergeMergesRecursiveArray(): void
     {
-        /** @var \Cocur\Chain\Link\Merge $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Merge');
+        /** @var Merge $mock */
+        $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = ['foo' => [0, 1], 'bar' => ['a', 'b']];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(['foo' => [2, 3], 'bar' => ['c', 'd']], ['recursive' => true]);
 
         $this->assertEquals(['foo' => [0, 1, 2, 3], 'bar' => ['a', 'b', 'c', 'd']], $mock->array);
@@ -58,11 +62,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Merge::merge()
      */
-    public function mergeMergesRecursiveChain()
+    public function mergeMergesRecursiveChain(): void
     {
-        /** @var \Cocur\Chain\Link\Merge $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Merge');
+        /** @var Merge $mock */
+        $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = ['foo' => [0, 1], 'bar' => ['a', 'b']];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(Chain::create(['foo' => [2, 3], 'bar' => ['c', 'd']]), ['recursive' => true]);
 
         $this->assertEquals(['foo' => [0, 1, 2, 3], 'bar' => ['a', 'b', 'c', 'd']], $mock->array);

--- a/tests/Link/PadTest.php
+++ b/tests/Link/PadTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * PadTest.
  *
@@ -15,11 +17,12 @@ class PadTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Pad::pad()
      */
-    public function padExtendsArray()
+    public function padExtendsArray(): void
     {
-        /** @var \Cocur\Chain\Link\Pad $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Pad');
+        /** @var Pad $mock */
+        $mock        = $this->getMockForTrait(Pad::class);
         $mock->array = [0];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->pad(3, 5);
 
         $this->assertEquals([0, 5, 5], $mock->array);

--- a/tests/Link/PopTest.php
+++ b/tests/Link/PopTest.php
@@ -15,10 +15,10 @@ class PopTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Pop::pop()
      */
-    public function popPopsElementOff()
+    public function popPopsElementOff(): void
     {
-        /** @var \Cocur\Chain\Link\Pop $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Pop');
+        /** @var Pop $mock */
+        $mock        = $this->getMockForTrait(Pop::class);
         $mock->array = [0, 1];
 
         $this->assertEquals(1, $mock->pop());

--- a/tests/Link/ProductTest.php
+++ b/tests/Link/ProductTest.php
@@ -15,10 +15,10 @@ class ProductTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Product::product()
      */
-    public function productMultipliesElements()
+    public function productMultipliesElements(): void
     {
-        /** @var \Cocur\Chain\Link\Product $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Product');
+        /** @var Product $mock */
+        $mock        = $this->getMockForTrait(Product::class);
         $mock->array = [2, 3];
 
         $this->assertEquals(6, $mock->product());

--- a/tests/Link/PushTest.php
+++ b/tests/Link/PushTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * PushTest.
  *
@@ -15,11 +17,12 @@ class PushTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Push::push()
      */
-    public function pushPushesElementOntoTheEnd()
+    public function pushPushesElementOntoTheEnd(): void
     {
-        /** @var \Cocur\Chain\Link\Push $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Push');
+        /** @var Push $mock */
+        $mock        = $this->getMockForTrait(Push::class);
         $mock->array = [0];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->push(1);
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/RandTest.php
+++ b/tests/Link/RandTest.php
@@ -15,10 +15,10 @@ class RandTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Rand::rand()
      */
-    public function randSelectsRandomElement()
+    public function randSelectsRandomElement(): void
     {
-        /** @var \Cocur\Chain\Link\Rand $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Rand');
+        /** @var Rand $mock */
+        $mock        = $this->getMockForTrait(Rand::class);
         $mock->array = [0, 1, 2];
 
         $rand = $mock->rand();

--- a/tests/Link/ReduceTest.php
+++ b/tests/Link/ReduceTest.php
@@ -15,10 +15,10 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Reduce::reduce()
      */
-    public function reduceReducesTheChain()
+    public function reduceReducesTheChain(): void
     {
-        /** @var \Cocur\Chain\Link\Reduce $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Reduce');
+        /** @var Reduce $mock */
+        $mock        = $this->getMockForTrait(Reduce::class);
         $mock->array = [1, 2, 3];
 
         $this->assertEquals(6, $mock->reduce(function ($s, $v) { return $s + $v; }));

--- a/tests/Link/ReplaceTest.php
+++ b/tests/Link/ReplaceTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * ReplaceTest.
  *
@@ -15,11 +17,12 @@ class ReplaceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Replace::replace()
      */
-    public function replaceReplacesValuesInArray()
+    public function replaceReplacesValuesInArray(): void
     {
-        /** @var \Cocur\Chain\Link\Replace $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Replace');
+        /** @var Replace $mock */
+        $mock        = $this->getMockForTrait(Replace::class);
         $mock->array = [0, 1, 2, 3, 4];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->replace([1 => 42, 3 => 69]);
 
         $this->assertEquals(0, $mock->array[0]);

--- a/tests/Link/ReverseTest.php
+++ b/tests/Link/ReverseTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * ReverseTest.
  *
@@ -15,11 +17,12 @@ class ReverseTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Reverse::reverse()
      */
-    public function reverseReversesTheChain()
+    public function reverseReversesTheChain(): void
     {
-        /** @var \Cocur\Chain\Link\Reverse $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Reverse');
+        /** @var Reverse $mock */
+        $mock        = $this->getMockForTrait(Reverse::class);
         $mock->array = [0, 1];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->reverse();
 
         $this->assertEquals([1, 0], $mock->array);

--- a/tests/Link/SearchTest.php
+++ b/tests/Link/SearchTest.php
@@ -15,10 +15,10 @@ class SearchTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Search::search()
      */
-    public function searchSearchesArrayForValue()
+    public function searchSearchesArrayForValue(): void
     {
-        /** @var \Cocur\Chain\Link\Search $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Search');
+        /** @var Search $mock */
+        $mock        = $this->getMockForTrait(Search::class);
         $mock->array = ['foo', 'bar'];
 
         $this->assertEquals(1, $mock->search('bar'));

--- a/tests/Link/ShiftTest.php
+++ b/tests/Link/ShiftTest.php
@@ -15,10 +15,10 @@ class ShiftTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Shift::shift()
      */
-    public function shiftShiftsElementOff()
+    public function shiftShiftsElementOff(): void
     {
-        /** @var \Cocur\Chain\Link\Shift $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Shift');
+        /** @var Shift $mock */
+        $mock        = $this->getMockForTrait(Shift::class);
         $mock->array = [0, 1];
 
         $this->assertEquals(0, $mock->shift());

--- a/tests/Link/ShuffleTest.php
+++ b/tests/Link/ShuffleTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * ShuffleTest.
  *
@@ -15,11 +17,12 @@ class ShuffleTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Shuffle::shuffle()
      */
-    public function shuffleRandomizesChain()
+    public function shuffleRandomizesChain(): void
     {
-        /** @var \Cocur\Chain\Link\Shuffle $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Shuffle');
+        /** @var Shuffle $mock */
+        $mock        = $this->getMockForTrait(Shuffle::class);
         $mock->array = [0, 1, 3, 4, 5, 6, 7, 8, 9];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->shuffle();
 
         $this->assertNotEquals([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], $mock->array);

--- a/tests/Link/SliceTest.php
+++ b/tests/Link/SliceTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * SliceTest.
  *
@@ -15,11 +17,12 @@ class SliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Slice::slice()
      */
-    public function sliceSlicesArray()
+    public function sliceSlicesArray(): void
     {
-        /** @var \Cocur\Chain\Link\Slice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Slice');
+        /** @var Slice $mock */
+        $mock        = $this->getMockForTrait(Slice::class);
         $mock->array = [0, 1, 2, 3, 4, 5];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->slice(1, 3);
 
         $this->assertEquals([1, 2, 3], $mock->array);
@@ -29,11 +32,12 @@ class SliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Slice::slice()
      */
-    public function sliceCanChain()
+    public function sliceCanChain(): void
     {
-        /** @var \Cocur\Chain\Link\Slice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Slice');
+        /** @var Slice $mock */
+        $mock        = $this->getMockForTrait(Slice::class);
         $mock->array = [0, 1, 2, 3, 4, 5];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $result      = $mock->slice(1, 3)->array;
         $this->assertEquals([1, 2, 3], $result);
     }

--- a/tests/Link/SortKeysTest.php
+++ b/tests/Link/SortKeysTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * SortKeysTest.
  *
@@ -16,12 +18,13 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
      * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
      */
-    public function sortKeysWithDefaultSorting()
+    public function sortKeysWithDefaultSorting(): void
     {
-        /** @var \Cocur\Chain\Link\SortKeys $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        /** @var SortKeys $mock */
+        $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['apple' => 4, 'banana' => 3, 'lemon' => 1, 'orange' => 2], $mock->sortKeys()->array);
     }
 
@@ -30,12 +33,13 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
      * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
      */
-    public function sortKeysWithAlternativeSortingAlgorithm()
+    public function sortKeysWithAlternativeSortingAlgorithm(): void
     {
-        /** @var \Cocur\Chain\Link\SortKeys $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        /** @var SortKeys $mock */
+        $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['111' => 1, '21' => 2, '112' => 3, '22' => 4];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['21' => 2, '22' => 4, '111' => 1, '112' => 3], $mock->sortKeys()->array);
     }
 
@@ -44,15 +48,16 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
      * @covers Cocur\Chain\Link\SortKeys::sortKeysWithFlags()
      */
-    public function sortKeysWithDefaultSortingAndReverseOption()
+    public function sortKeysWithDefaultSortingAndReverseOption(): void
     {
-        /** @var \Cocur\Chain\Link\SortKeys $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        /** @var SortKeys $mock */
+        $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             ['orange' => 2, 'lemon' => 1, 'banana' => 3, 'apple' => 4],
-            $mock->sortKeys(null, ['reverse' => true])->array
+            $mock->sortKeys(SORT_REGULAR, ['reverse' => true])->array
         );
     }
 
@@ -60,12 +65,13 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\SortKeys::sortKeys()
      */
-    public function sortKeysWithFunction()
+    public function sortKeysWithFunction(): void
     {
-        /** @var \Cocur\Chain\Link\SortKeys $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\SortKeys');
+        /** @var SortKeys $mock */
+        $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['kiwi' => 2, 'banana' => 3, 'apple' => 4];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
         $this->assertSame(['kiwi' => 2, 'apple' => 4, 'banana' => 3], $mock->sortKeys(function ($a, $b) {
             $a = strlen($a);

--- a/tests/Link/SortTest.php
+++ b/tests/Link/SortTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * SortTest.
  *
@@ -16,12 +18,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithDefaultSorting()
+    public function sortWithDefaultSorting(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['apple', 'banana', 'lemon', 'orange'], $mock->sort()->array);
     }
 
@@ -30,12 +33,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithAlternativeSortingAlgorithm()
+    public function sortWithAlternativeSortingAlgorithm(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['111', '21', '112', '22'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['21', '22', '111', '112'], $mock->sort(SORT_NUMERIC)->array);
     }
 
@@ -44,12 +48,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithDefaultSortingAndAssocOption()
+    public function sortWithDefaultSortingAndAssocOption(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             [3 => 'apple', 2 => 'banana', 0 => 'lemon', 1 => 'orange'],
             $mock->sort(null, ['assoc' => true])->array
@@ -61,12 +66,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithDefaultSortingAndReverseOption()
+    public function sortWithDefaultSortingAndReverseOption(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             ['orange', 'lemon', 'banana', 'apple'],
             $mock->sort(null, ['reverse' => true])->array
@@ -78,12 +84,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithDefaultSortingAndAssocAndReverseOption()
+    public function sortWithDefaultSortingAndAssocAndReverseOption(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             [1 => 'orange', 0 => 'lemon', 2 => 'banana', 3 => 'apple'],
             $mock->sort(null, ['assoc' => true, 'reverse' => true])->array
@@ -95,14 +102,15 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithCallback()
      */
-    public function sortWithFunction()
+    public function sortWithFunction(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['kiwi', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
-        $this->assertSame(['kiwi', 'apple', 'banana'], $mock->sort(function ($a, $b) {
+        $this->assertSame(['kiwi', 'apple', 'banana'], $mock->sort(function ($a, $b): int {
             $a = strlen($a);
             $b = strlen($b);
 
@@ -115,14 +123,15 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithCallback()
      */
-    public function sortWithFunctionAndAssocOption()
+    public function sortWithFunctionAndAssocOption(): void
     {
-        /** @var \Cocur\Chain\Link\Sort $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['kiwi', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
-        $this->assertSame([0 => 'kiwi', 2 => 'apple', 1 => 'banana'], $mock->sort(function ($a, $b) {
+        $this->assertSame([0 => 'kiwi', 2 => 'apple', 1 => 'banana'], $mock->sort(function ($a, $b): int {
             $a = strlen($a);
             $b = strlen($b);
 
@@ -135,12 +144,13 @@ class SortTest extends \PHPUnit\Framework\TestCase
      * @covers Cocur\Chain\Link\Sort::sort()
      * @covers Cocur\Chain\Link\Sort::sortWithFlags()
      */
-    public function sortWithNatCaseSort()
+    public function sortWithNatCaseSort(): void
     {
-        /** @var \Cocur\Chain\Link\Sort */
-        $mock = $this->getMockForTrait('Cocur\Chain\Link\Sort');
+        /** @var Sort $mock */
+        $mock = $this->getMockForTrait(Sort::class);
         $mock->array = ['IMG0.png', 'img12.png', 'img10.png', 'img2.png', 'img1.png', 'IMG3.png'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $result = $mock->sort(SORT_NATURAL | SORT_FLAG_CASE);
         $this->assertSame('IMG0.png', $result->array[0]);
         $this->assertSame('img1.png', $result->array[1]);

--- a/tests/Link/SpliceTest.php
+++ b/tests/Link/SpliceTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * SpliceTest.
  *
@@ -15,12 +17,13 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Splice::splice()
      */
-    public function spliceRemovesAPortionOfTheArray()
+    public function spliceRemovesAPortionOfTheArray(): void
     {
-        /** @var \Cocur\Chain\Link\Splice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Splice');
+        /** @var Splice $mock */
+        $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(2);
         $this->assertSame(['lemon', 'orange'], $mock->array);
     }
@@ -29,12 +32,13 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Splice::splice()
      */
-    public function spliceRemovesAPortionOfTheArrayWithNegativeLength()
+    public function spliceRemovesAPortionOfTheArrayWithNegativeLength(): void
     {
-        /** @var \Cocur\Chain\Link\Splice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Splice');
+        /** @var Splice $mock */
+        $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(1, -1);
         $this->assertSame(['lemon', 'apple'], $mock->array);
     }
@@ -43,12 +47,13 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Splice::splice()
      */
-    public function spliceRemovesAPortionOfTheArrayWithReplacement()
+    public function spliceRemovesAPortionOfTheArrayWithReplacement(): void
     {
-        /** @var \Cocur\Chain\Link\Splice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Splice');
+        /** @var Splice $mock */
+        $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(1, 4, 'kiwi');
         $this->assertSame(['lemon', 'kiwi'], $mock->array);
     }
@@ -57,12 +62,13 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Splice::splice()
      */
-    public function spliceRemovesAPortionOfTheArrayWithArrayReplacement()
+    public function spliceRemovesAPortionOfTheArrayWithArrayReplacement(): void
     {
-        /** @var \Cocur\Chain\Link\Splice $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Splice');
+        /** @var Splice $mock */
+        $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(-1, 1, ['kiwi', 'pineapple']);
         $this->assertSame(['lemon', 'orange', 'banana', 'kiwi', 'pineapple'], $mock->array);
     }

--- a/tests/Link/SumTest.php
+++ b/tests/Link/SumTest.php
@@ -15,10 +15,10 @@ class SumTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Sum::sum()
      */
-    public function sumReturnsSumOfArray()
+    public function sumReturnsSumOfArray(): void
     {
-        /** @var \Cocur\Chain\Link\Sum $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Sum');
+        /** @var Sum $mock */
+        $mock        = $this->getMockForTrait(Sum::class);
         $mock->array = [1, 2, 3];
 
         $this->assertEquals(6, $mock->sum());

--- a/tests/Link/UniqueTest.php
+++ b/tests/Link/UniqueTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * UniqueTest.
  *
@@ -15,11 +17,12 @@ class UniqueTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Unique::unique()
      */
-    public function uniqueRemovesDuplicates()
+    public function uniqueRemovesDuplicates(): void
     {
-        /** @var \Cocur\Chain\Link\Unique $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Unique');
+        /** @var Unique $mock */
+        $mock        = $this->getMockForTrait(Unique::class);
         $mock->array = [0, 1, 0, 0];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->unique();
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/UnshiftTest.php
+++ b/tests/Link/UnshiftTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * UnshiftTest.
  *
@@ -15,11 +17,12 @@ class UnshiftTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Unshift::unshift()
      */
-    public function unshiftPrependsElement()
+    public function unshiftPrependsElement(): void
     {
-        /** @var \Cocur\Chain\Link\Unshift $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Unshift');
+        /** @var Unshift $mock */
+        $mock        = $this->getMockForTrait(Unshift::class);
         $mock->array = [1];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->unshift(0);
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/ValuesTest.php
+++ b/tests/Link/ValuesTest.php
@@ -2,6 +2,8 @@
 
 namespace Cocur\Chain\Link;
 
+use Cocur\Chain\ChainTest;
+
 /**
  * ValuesTest.
  *
@@ -15,11 +17,12 @@ class ValuesTest extends \PHPUnit\Framework\TestCase
      * @test
      * @covers Cocur\Chain\Link\Values::values()
      */
-    public function valuesChangesArrayToValues()
+    public function valuesChangesArrayToValues(): void
     {
-        /** @var \Cocur\Chain\Link\Values $mock */
-        $mock        = $this->getMockForTrait('Cocur\Chain\Link\Values');
+        /** @var Values $mock */
+        $mock        = $this->getMockForTrait(Values::class);
         $mock->array = ['foo' => 1, 'bar' => 2];
+        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->values();
 
         $this->assertEquals([1, 2], $mock->array);


### PR DESCRIPTION
I've added strong typing everywhere it was possible.
I also:
- removed all magic strings for FQCN
- fixed namespaces in tests comment doc (phpStorm is now happy and successfully identify the object types)
- I initially did the same thing for `@covers` annotations but reverted it because the FQCN is required

Adding strong typing made me spot two bugs that I fixed in the meantime:
- splice wasn't returning this and therefore wasn't fluent (also added doc for this one)
- test for `sortKeysWithDefaultSortingAndReverseOption` had a bug, you were passing null assuming it would take the default value. This is not how PHP handles that, default values are provided only if you pass nothing at all. Passing an explicit `null` will give you a `null` (now a `TypeError` as the param isn't nullable). As you were passing the second argument you've got no choice: you're forced to pass the first.