### PR TITLE
Add an extension point to the inheritance chain

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -49,7 +49,7 @@ use Countable;
  * @author    Florian Eckerstorfer
  * @copyright 2015-2017 Florian Eckerstorfer
  */
-class Chain extends AbstractChain implements Countable
+class Chain extends ExtensibleChain implements Countable
 {
     use ChangeKeyCase,
         Combine,

--- a/src/ExtensibleChain.php
+++ b/src/ExtensibleChain.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cocur\Chain;
+
+/**
+ * ExtensibleChain
+ * 
+ * Use this class as a potential extension point for user-defined traits.
+ * You can provide your own implementation by using Composer
+ * `autoload.classmap` and `autoload.exclude-from-classmap`:
+ * ```
+ * {
+ *     "autoload": {
+ *         "classmap": ["src/chain/ExtensibleChain.php"],
+ *         "exclude-from-classmap": ["vendor/cocur/chain/src/ExtensibleChain.php"]
+ *     }
+ * }
+ * ```
+ *
+ * @see https://getcomposer.org/doc/04-schema.md#classmap
+ * @see https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps
+ * @author    Nicolas Reynis
+ */
+class ExtensibleChain extends AbstractChain
+{
+}

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -69,6 +69,16 @@ class ChainTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
+    public function chainIsExtensible(): void
+    {
+        $c = new Chain();
+
+        $this->assertTrue($c instanceof ExtensibleChain);
+    }
+
+    /**
+     * @test
+     */
     public function chainHasTraits(): void
     {
         $c = new Chain();


### PR DESCRIPTION
I've searched for quite some time a way to open Chain to extension. This is not an easy task because `Chain` being fluent, subclassing it will break the API: library-defined method would not return the same type that user-defined ones.

I didn't wan't to use reflection, I wanted something with no runtime cost and that would work well with IDE. So it must be a static solution.

I came to the conclusion that the only real way to solve this was to inject extensions in the middle of the inheritance chain and use composer to let the user shoehorn his methods.

This can be done with a combimation of `autoload.classmap` and `autoload.exclude-from-classmap`.
```json
{
    "autoload": {
        "classmap": ["src/chain/ExtensibleChain.php"],
        "exclude-from-classmap": ["vendor/cocur/chain/src/ExtensibleChain.php"]
    }
}
 ```

Additionally, if the IDE isn't strictly conforming to composer and chock on multiple class definition ([like php storm for example](https://stackoverflow.com/questions/49157401/how-to-resolve-phpstorm-alert-multiple-definitions-for-a-class)), a `post-autoload-dump` can be added. This is totally unecessary for runtime, it's just to keep the IDE happy.

```json
"scripts": {
    "post-autoload-dump": [
        "rm vendor/cocur/chain/src/ExtensibleChain.php"
    ]
}
```

Please let me know what you think about it. If you think it can be usefull I'll add a bit of documentation to the PR.