### PR TITLE
Use self return type

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -102,9 +102,9 @@ class Chain extends AbstractChain implements Countable
     /**
      * @param array $array
      *
-     * @return Chain
+     * @return self
      */
-    public static function create(array $array = []): Chain
+    public static function create(array $array = []): self
     {
         return new static($array);
     }
@@ -115,9 +115,9 @@ class Chain extends AbstractChain implements Countable
      * @param array  $options   If the option `regexp` is `true` the string is split by using `preg_split()`, otherwise
      *                          `explode()` is used.
      *
-     * @return Chain
+     * @return self
      */
-    public static function createFromString(string $delimiter, string $string, array $options = []): Chain
+    public static function createFromString(string $delimiter, string $string, array $options = []): self
     {
         $options = array_merge(['regexp' => false], $options);
         $chain   = new static();

--- a/src/Link/ChangeKeyCase.php
+++ b/src/Link/ChangeKeyCase.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Class ChangeKeyCase.
  *
@@ -18,9 +16,9 @@ trait ChangeKeyCase
      *
      * @param int $case Either `CASE_UPPER` or `CASE_LOWER` (default).
      *
-     * @return Chain
+     * @return self
      */
-    public function changeKeyCase(int $case = CASE_LOWER): Chain
+    public function changeKeyCase(int $case = CASE_LOWER): self
     {
         $this->array = array_change_key_case($this->array, $case);
 

--- a/src/Link/Combine.php
+++ b/src/Link/Combine.php
@@ -18,9 +18,9 @@ trait Combine
      *                            will be converted to string.
      * @param Chain|array $values Array or instance of `Cocur\Chain\Chain` of values to be used.
      *
-     * @return Chain
+     * @return self
      */
-    public function combine($keys, $values): Chain
+    public function combine($keys, $values): self
     {
         $this->array = array_combine(
             $keys instanceof Chain ? $keys->array : $keys,

--- a/src/Link/Diff.php
+++ b/src/Link/Diff.php
@@ -20,9 +20,9 @@ trait Diff
      *
      * @param Chain|array $array2 An array or instance of `Cocur\Chain\Chain` to compare against.
      *
-     * @return Chain
+     * @return self
      */
-    public function diff($array2): Chain
+    public function diff($array2): self
     {
         $this->array = array_diff(
             $this->array,

--- a/src/Link/Fill.php
+++ b/src/Link/Fill.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Fill.
  *
@@ -23,9 +21,9 @@ trait Fill
      * @param int   $num        Number of elements to insert. Must be greater than or equal to zero.
      * @param mixed $value      Value to use for filling.
      *
-     * @return Chain
+     * @return self
      */
-    public static function fill(int $startIndex, int $num, $value = null): Chain
+    public static function fill(int $startIndex, int $num, $value = null): self
     {
         return new self(array_fill($startIndex, $num, $value));
     }

--- a/src/Link/Filter.php
+++ b/src/Link/Filter.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Filter.
  *
@@ -20,9 +18,9 @@ trait Filter
      *
      * @param callable $callback The callback function to use.
      *
-     * @return Chain
+     * @return self
      */
-    public function filter(callable $callback): Chain
+    public function filter(callable $callback): self
     {
         $this->array = array_filter($this->array, $callback, ARRAY_FILTER_USE_BOTH);
 

--- a/src/Link/Find.php
+++ b/src/Link/Find.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Find
  *

--- a/src/Link/FlatMap.php
+++ b/src/Link/FlatMap.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * FlatMap.
  *
@@ -14,9 +12,9 @@ trait FlatMap
     /**
      * @param callable $callback
      *
-     * @return Chain
+     * @return self
      */
-    public function flatMap(callable $callback): Chain
+    public function flatMap(callable $callback): self
     {
         $flattened = [];
         foreach ($this->array as $index => $element) {

--- a/src/Link/Flip.php
+++ b/src/Link/Flip.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Flip.
  *
@@ -13,9 +11,9 @@ use Cocur\Chain\Chain;
 trait Flip
 {
     /**
-     * @return Chain
+     * @return self
      */
-    public function flip(): Chain
+    public function flip(): self
     {
         $this->array = array_flip($this->array);
 

--- a/src/Link/Intersect.php
+++ b/src/Link/Intersect.php
@@ -15,9 +15,9 @@ trait Intersect
     /**
      * @param Chain|array $array2
      *
-     * @return Chain
+     * @return self
      */
-    public function intersect($array2): Chain
+    public function intersect($array2): self
     {
         $this->array = array_intersect($this->array, $array2 instanceof Chain ? $array2->array : $array2);
 

--- a/src/Link/IntersectAssoc.php
+++ b/src/Link/IntersectAssoc.php
@@ -15,9 +15,9 @@ trait IntersectAssoc
     /**
      * @param Chain|array $array
      *
-     * @return Chain
+     * @return self
      */
-    public function intersectAssoc($array): Chain
+    public function intersectAssoc($array): self
     {
         $this->array = array_intersect_assoc($this->array, $array instanceof Chain ? $array->array : $array);
 

--- a/src/Link/IntersectKey.php
+++ b/src/Link/IntersectKey.php
@@ -15,9 +15,9 @@ trait IntersectKey
     /**
      * @param Chain|array $array
      *
-     * @return Chain
+     * @return self
      */
-    public function intersectKey($array): Chain
+    public function intersectKey($array): self
     {
         $this->array = array_intersect_key($this->array, $array instanceof Chain ? $array->array : $array);
 

--- a/src/Link/Keys.php
+++ b/src/Link/Keys.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Keys.
  *
@@ -13,9 +11,9 @@ use Cocur\Chain\Chain;
 trait Keys
 {
     /**
-     * @return Chain
+     * @return self
      */
-    public function keys(): Chain
+    public function keys(): self
     {
         $this->array = array_keys($this->array);
 

--- a/src/Link/Map.php
+++ b/src/Link/Map.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Map.
  *
@@ -15,9 +13,9 @@ trait Map
     /**
      * @param callable $callback
      *
-     * @return Chain
+     * @return self
      */
-    public function map(callable $callback): Chain
+    public function map(callable $callback): self
     {
         foreach ($this->array as $index => $element) {
             $this->array[$index] = $callback($element, $index);

--- a/src/Link/Merge.php
+++ b/src/Link/Merge.php
@@ -20,9 +20,9 @@ trait Merge
      * @param Chain|array $array   Array to merge with
      * @param array       $options Options, including `recursive` to merge arrays recursive.
      *
-     * @return Chain
+     * @return self
      */
-    public function merge($array, array $options = []): Chain
+    public function merge($array, array $options = []): self
     {
         $options = array_merge(['recursive' => false], $options);
 

--- a/src/Link/Pad.php
+++ b/src/Link/Pad.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Pad.
  *
@@ -16,9 +14,9 @@ trait Pad
      * @param int   $size
      * @param mixed $value
      *
-     * @return Chain
+     * @return self
      */
-    public function pad(int $size, $value): Chain
+    public function pad(int $size, $value): self
     {
         $this->array = array_pad($this->array, $size, $value);
 

--- a/src/Link/Push.php
+++ b/src/Link/Push.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Push.
  *
@@ -15,9 +13,9 @@ trait Push
     /**
      * @param mixed $element
      *
-     * @return Chain
+     * @return self
      */
-    public function push($element): Chain
+    public function push($element): self
     {
         array_push($this->array, $element);
 

--- a/src/Link/Replace.php
+++ b/src/Link/Replace.php
@@ -15,9 +15,9 @@ trait Replace
     /**
      * @param Chain|array $array
      *
-     * @return Chain
+     * @return self
      */
-    public function replace($array): Chain
+    public function replace($array): self
     {
         $this->array = array_replace($this->array, $array instanceof Chain ? $chain->array : $array);
 

--- a/src/Link/Reverse.php
+++ b/src/Link/Reverse.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Reverse.
  *
@@ -15,9 +13,9 @@ trait Reverse
     /**
      * @param bool $preserveKeys
      *
-     * @return Chain
+     * @return self
      */
-    public function reverse(bool $preserveKeys = false): Chain
+    public function reverse(bool $preserveKeys = false): self
     {
         $this->array = array_reverse($this->array, $preserveKeys);
 

--- a/src/Link/Shuffle.php
+++ b/src/Link/Shuffle.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Shuffle.
  *
@@ -13,9 +11,9 @@ use Cocur\Chain\Chain;
 trait Shuffle
 {
     /**
-     * @return Chain
+     * @return self
      */
-    public function shuffle(): Chain
+    public function shuffle(): self
     {
         shuffle($this->array);
 

--- a/src/Link/Slice.php
+++ b/src/Link/Slice.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Slice.
  *
@@ -17,9 +15,9 @@ trait Slice
      * @param int|null $length
      * @param bool     $preserveKeys
      *
-     * @return Chain
+     * @return self
      */
-    public function slice(int $offset, ?int $length = null, bool $preserveKeys = false): Chain
+    public function slice(int $offset, ?int $length = null, bool $preserveKeys = false): self
     {
         $this->array = array_slice($this->array, $offset, $length, $preserveKeys);
 

--- a/src/Link/Sort.php
+++ b/src/Link/Sort.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Class Sort.
  *
@@ -18,9 +16,9 @@ trait Sort
      * @param int|callable $sortBy
      * @param array        $options
      *
-     * @return Chain
+     * @return self
      */
-    public function sort($sortBy = SORT_REGULAR, array $options = []): Chain
+    public function sort($sortBy = SORT_REGULAR, array $options = []): self
     {
         if (!$sortBy) {
             $sortBy = SORT_REGULAR;

--- a/src/Link/SortKeys.php
+++ b/src/Link/SortKeys.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Class SortKeys.
  *
@@ -18,9 +16,9 @@ trait SortKeys
      * @param int|callable $sortBy
      * @param array        $options
      *
-     * @return Chain
+     * @return self
      */
-    public function sortKeys($sortBy = SORT_REGULAR, array $options = []): Chain
+    public function sortKeys($sortBy = SORT_REGULAR, array $options = []): self
     {
         if ($sortBy && is_callable($sortBy)) {
             uksort($this->array, $sortBy);

--- a/src/Link/Splice.php
+++ b/src/Link/Splice.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Splice.
  *
@@ -19,9 +17,9 @@ trait Splice
      * @param int|null $length
      * @param array $replacement
      *
-     * @return Chain
+     * @return self
      */
-    public function splice(int $offset, ?int $length = null, $replacement = []): Chain
+    public function splice(int $offset, ?int $length = null, $replacement = []): self
     {
         if ($length) {
             array_splice($this->array, $offset, $length, $replacement);

--- a/src/Link/Unique.php
+++ b/src/Link/Unique.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Unique.
  *
@@ -15,9 +13,9 @@ trait Unique
     /**
      * @param int $sortFlags
      *
-     * @return Chain
+     * @return self
      */
-    public function unique(int $sortFlags = SORT_STRING): Chain
+    public function unique(int $sortFlags = SORT_STRING): self
     {
         $this->array = array_unique($this->array, $sortFlags);
 

--- a/src/Link/Unshift.php
+++ b/src/Link/Unshift.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Unshift.
  *
@@ -15,9 +13,9 @@ trait Unshift
     /**
      * @param mixed $element
      *
-     * @return Chain
+     * @return self
      */
-    public function unshift($element): Chain
+    public function unshift($element): self
     {
         array_unshift($this->array, $element);
 

--- a/src/Link/Values.php
+++ b/src/Link/Values.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * Values.
  *
@@ -13,9 +11,9 @@ use Cocur\Chain\Chain;
 trait Values
 {
     /**
-     * @return Chain
+     * @return self
      */
-    public function values(): Chain
+    public function values(): self
     {
         $this->array = array_values($this->array);
 

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain;
 
-use PHPUnit\Framework\MockObject\MockObject;
-
 /**
  * ChainTest.
  *
@@ -13,23 +11,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class ChainTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * Generate the expected TypeError that will be emitted when mocking Trait using Fluent design.
-     * This serve two purposes:
-     * - swallow the error and keep the test passing
-     * - validate that the method is effectively fluent.
-     *
-     * @param MockObject $mockedTrait
-     * @return string
-     */
-    public static function getFluentTypeErrorForMockedTrait(MockObject $mockedTrait): string
-    {
-        $mockClass = get_class($mockedTrait);
-        $traitClass = substr($mockClass, 5, -9);
-        return sprintf('/Return value of %s::.*?\\(\\) must be an instance of %s, instance of %s returned/',
-            $traitClass, str_replace('\\', '\\\\', Chain::class), $mockClass);
-    }
-
     /**
      * @test
      * @covers Cocur\Chain\Chain::__construct()

--- a/tests/Link/ChangeKeyCaseTest.php
+++ b/tests/Link/ChangeKeyCaseTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * CountTest.
  *
@@ -18,12 +16,10 @@ class ChangeKeyCaseTest extends \PHPUnit\Framework\TestCase
      */
     public function changeKeyCaseDefaultsToLower(): void
     {
-        $this->expectException(\TypeError::class);
         /** @var ChangeKeyCase $mock */
         $mock        = $this->getMockForTrait(ChangeKeyCase::class);
         $mock->array = ['FoO' => 1, 'BAR' => 2];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 1, 'bar' => 2], $mock->changeKeyCase()->array);
     }
 
@@ -37,7 +33,6 @@ class ChangeKeyCaseTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(ChangeKeyCase::class);
         $mock->array = ['FoO' => 1, 'bar' => 2];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['FOO' => 1, 'BAR' => 2], $mock->changeKeyCase(CASE_UPPER)->array);
     }
 }

--- a/tests/Link/CombineTest.php
+++ b/tests/Link/CombineTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 
 /**
@@ -26,7 +25,6 @@ class CombineTest extends \PHPUnit\Framework\TestCase
         $keys   = Chain::create(['foo', 'bar']);
         $values = Chain::create([42, 43]);
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 42, 'bar' => 43], $mock->combine($keys, $values)->array);
     }
 
@@ -42,7 +40,6 @@ class CombineTest extends \PHPUnit\Framework\TestCase
         $keys   = ['foo', 'bar'];
         $values = [42, 43];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertEquals(['foo' => 42, 'bar' => 43], $mock->combine($keys, $values)->array);
     }
 }

--- a/tests/Link/DiffTest.php
+++ b/tests/Link/DiffTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 /**
  * DiffTest.
@@ -23,7 +22,6 @@ class DiffTest extends \PHPUnit\Framework\TestCase
         /** @var Diff $mock */
         $mock        = $this->getMockForTrait(Diff::class);
         $mock->array = [0, 1, 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->diff([1, 2, 3]);
 
         $this->assertEquals([0], $mock->array);
@@ -38,7 +36,6 @@ class DiffTest extends \PHPUnit\Framework\TestCase
         /** @var Diff $mock */
         $mock        = $this->getMockForTrait(Diff::class);
         $mock->array = [0, 1, 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->diff(Chain::create([1, 2, 3]));
 
         $this->assertEquals([0], $mock->array);

--- a/tests/Link/FillTest.php
+++ b/tests/Link/FillTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\Chain;
-
 /**
  * FillTest.
  *
@@ -19,9 +17,6 @@ class FillTest extends \PHPUnit\Framework\TestCase
      */
     public function fillCreatesAFilledChain(): void
     {
-        $fluentTypeErrorMessage = sprintf('Return value of %1$s::fill() must be an instance of %2$s, instance of %1$s returned',
-            ChainMock::class, Chain::class);
-        $this->expectExceptionMessage($fluentTypeErrorMessage);
         $mock = ChainMock::fill(0, 10);
 
         $this->assertIsArray($mock->array);

--- a/tests/Link/FilterTest.php
+++ b/tests/Link/FilterTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * FilterTest.
  *
@@ -22,7 +20,6 @@ class FilterTest extends \PHPUnit\Framework\TestCase
         /** @var Filter $mock */
         $mock        = $this->getMockForTrait(Filter::class);
         $mock->array = [0, 1, 2, 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->filter(function ($v): bool { return $v & 1; });
 
         $this->assertCount(2, $mock->array);
@@ -41,7 +38,6 @@ class FilterTest extends \PHPUnit\Framework\TestCase
         /** @var Filter $mock */
         $mock        = $this->getMockForTrait(Filter::class);
         $mock->array = ["0" => 0, "1" => 1, "2" => 2, "3" => 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->filter(function ($v, $k): bool { return intval($k) & 1; });
 
         $this->assertCount(2, $mock->array);

--- a/tests/Link/FirstTest.php
+++ b/tests/Link/FirstTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use \PHPUnit\Framework\TestCase;
-
 /**
  * FirstTest.
  *

--- a/tests/Link/FlatMapTest.php
+++ b/tests/Link/FlatMapTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * MapTest.
  *
@@ -21,7 +19,6 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
         /** @var FlatMap $mock */
         $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['foobar', 'bar'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v) { return [str_replace('bar', 'foo', $v)]; });
 
         $this->assertEquals('foofoo', $mock->array[0]);
@@ -37,7 +34,6 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
         /** @var FlatMap $mock */
         $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['foo' => 'fizz', 'bar' => 'buzz'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v, $k) {
             return $k == 'foo' ? [str_replace('fizz', 'bang', $v)] : [$v];
         });
@@ -54,7 +50,6 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
         /** @var FlatMap $mock */
         $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = ['fizz', 'buzz'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v, $k) {
             return $k == 1 ? [$v] : $v;
         });
@@ -71,7 +66,6 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
         /** @var FlatMap $mock */
         $mock        = $this->getMockForTrait(FlatMap::class);
         $mock->array = [];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flatMap(function ($v) {
             return $v;
         });

--- a/tests/Link/FlipTest.php
+++ b/tests/Link/FlipTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * FlipTest.
  *
@@ -22,7 +20,6 @@ class FlipTest extends \PHPUnit\Framework\TestCase
         /** @var Flip $mock */
         $mock        = $this->getMockForTrait(Flip::class);
         $mock->array = ['foo', 'bar'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->flip();
 
         $this->assertEquals(['foo' => 0, 'bar' => 1], $mock->array);

--- a/tests/Link/IntersectAssocTest.php
+++ b/tests/Link/IntersectAssocTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 /**
  * IntersectAssocTest.
@@ -23,7 +22,6 @@ class IntersectAssocTest extends \PHPUnit\Framework\TestCase
         /** @var IntersectAssoc $mock */
         $mock        = $this->getMockForTrait(IntersectAssoc::class);
         $mock->array = [1, 2, 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectAssoc([3, 2, 1]);
 
         $this->assertContains(2, $mock->array);
@@ -40,7 +38,6 @@ class IntersectAssocTest extends \PHPUnit\Framework\TestCase
         /** @var IntersectAssoc $mock */
         $mock        = $this->getMockForTrait(IntersectAssoc::class);
         $mock->array = [1, 2, 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectAssoc(Chain::create([3, 2, 1]));
 
         $this->assertContains(2, $mock->array);

--- a/tests/Link/IntersectKeyTest.php
+++ b/tests/Link/IntersectKeyTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 /**
  * IntersectKeyTest.
@@ -23,7 +22,6 @@ class IntersectKeyTest extends \PHPUnit\Framework\TestCase
         /** @var IntersectKey $mock */
         $mock        = $this->getMockForTrait(IntersectKey::class);
         $mock->array = ['a' => 1, 'b' => 2, 'c' => 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectKey(['a' => 3, 'b' => 4, 'd' => 5]);
 
         $this->assertEquals(['a' => 1, 'b' => 2], $mock->array);
@@ -38,7 +36,6 @@ class IntersectKeyTest extends \PHPUnit\Framework\TestCase
         /** @var IntersectKey $mock */
         $mock        = $this->getMockForTrait(IntersectKey::class);
         $mock->array = ['a' => 1, 'b' => 2, 'c' => 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersectKey(Chain::create(['a' => 3, 'b' => 4, 'd' => 5]));
 
         $this->assertEquals(['a' => 1, 'b' => 2], $mock->array);

--- a/tests/Link/IntersectTest.php
+++ b/tests/Link/IntersectTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 /**
  * IntersectTest.
@@ -22,7 +21,6 @@ class IntersectTest extends \PHPUnit\Framework\TestCase
         /** @var Intersect $mock */
         $mock        = $this->getMockForTrait(Intersect::class);
         $mock->array = [1, 2, 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersect([3, 4, 5]);
 
         $this->assertContains(3, $mock->array);
@@ -39,7 +37,6 @@ class IntersectTest extends \PHPUnit\Framework\TestCase
         /** @var Intersect $mock */
         $mock        = $this->getMockForTrait(Intersect::class);
         $mock->array = [1, 2, 3];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->intersect(Chain::create([3, 4, 5]));
 
         $this->assertContains(3, $mock->array);

--- a/tests/Link/KeysTest.php
+++ b/tests/Link/KeysTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * KeysTest.
  *
@@ -22,7 +20,6 @@ class KeysTest extends \PHPUnit\Framework\TestCase
         /** @var Keys $mock */
         $mock        = $this->getMockForTrait(Keys::class);
         $mock->array = ['foo' => 1, 'bar' => 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->keys();
 
         $this->assertEquals(['foo', 'bar'], $mock->array);

--- a/tests/Link/MapTest.php
+++ b/tests/Link/MapTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * MapTest.
  *
@@ -22,7 +20,6 @@ class MapTest extends \PHPUnit\Framework\TestCase
         /** @var Map $mock */
         $mock        = $this->getMockForTrait(Map::class);
         $mock->array = ['foobar', 'bar'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->map(function ($v) { return str_replace('bar', 'foo', $v); });
 
         $this->assertEquals('foofoo', $mock->array[0]);
@@ -38,7 +35,6 @@ class MapTest extends \PHPUnit\Framework\TestCase
         /** @var Map $mock */
         $mock        = $this->getMockForTrait(Map::class);
         $mock->array = ['foo' => 'fizz', 'bar' => 'buzz'];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->map(function ($v, $k) {
             return $k == 'foo' ? str_replace('fizz', 'bang', $v) : $v;
         });

--- a/tests/Link/MergeTest.php
+++ b/tests/Link/MergeTest.php
@@ -3,7 +3,6 @@
 namespace Cocur\Chain\Link;
 
 use Cocur\Chain\Chain;
-use Cocur\Chain\ChainTest;
 
 /**
  * MergeTest.
@@ -22,7 +21,6 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         /** @var Merge $mock */
         $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = [0, 1, 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge([3, 4]);
 
         $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
@@ -37,7 +35,6 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         /** @var Merge $mock */
         $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = [0, 1, 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(Chain::create([3, 4]));
 
         $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
@@ -52,7 +49,6 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         /** @var Merge $mock */
         $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = ['foo' => [0, 1], 'bar' => ['a', 'b']];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(['foo' => [2, 3], 'bar' => ['c', 'd']], ['recursive' => true]);
 
         $this->assertEquals(['foo' => [0, 1, 2, 3], 'bar' => ['a', 'b', 'c', 'd']], $mock->array);
@@ -67,7 +63,6 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         /** @var Merge $mock */
         $mock        = $this->getMockForTrait(Merge::class);
         $mock->array = ['foo' => [0, 1], 'bar' => ['a', 'b']];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->merge(Chain::create(['foo' => [2, 3], 'bar' => ['c', 'd']]), ['recursive' => true]);
 
         $this->assertEquals(['foo' => [0, 1, 2, 3], 'bar' => ['a', 'b', 'c', 'd']], $mock->array);

--- a/tests/Link/PadTest.php
+++ b/tests/Link/PadTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * PadTest.
  *
@@ -22,7 +20,6 @@ class PadTest extends \PHPUnit\Framework\TestCase
         /** @var Pad $mock */
         $mock        = $this->getMockForTrait(Pad::class);
         $mock->array = [0];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->pad(3, 5);
 
         $this->assertEquals([0, 5, 5], $mock->array);

--- a/tests/Link/PushTest.php
+++ b/tests/Link/PushTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * PushTest.
  *
@@ -22,7 +20,6 @@ class PushTest extends \PHPUnit\Framework\TestCase
         /** @var Push $mock */
         $mock        = $this->getMockForTrait(Push::class);
         $mock->array = [0];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->push(1);
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/ReplaceTest.php
+++ b/tests/Link/ReplaceTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * ReplaceTest.
  *
@@ -22,7 +20,6 @@ class ReplaceTest extends \PHPUnit\Framework\TestCase
         /** @var Replace $mock */
         $mock        = $this->getMockForTrait(Replace::class);
         $mock->array = [0, 1, 2, 3, 4];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->replace([1 => 42, 3 => 69]);
 
         $this->assertEquals(0, $mock->array[0]);

--- a/tests/Link/ReverseTest.php
+++ b/tests/Link/ReverseTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * ReverseTest.
  *
@@ -22,7 +20,6 @@ class ReverseTest extends \PHPUnit\Framework\TestCase
         /** @var Reverse $mock */
         $mock        = $this->getMockForTrait(Reverse::class);
         $mock->array = [0, 1];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->reverse();
 
         $this->assertEquals([1, 0], $mock->array);

--- a/tests/Link/ShuffleTest.php
+++ b/tests/Link/ShuffleTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * ShuffleTest.
  *
@@ -22,7 +20,6 @@ class ShuffleTest extends \PHPUnit\Framework\TestCase
         /** @var Shuffle $mock */
         $mock        = $this->getMockForTrait(Shuffle::class);
         $mock->array = [0, 1, 3, 4, 5, 6, 7, 8, 9];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->shuffle();
 
         $this->assertNotEquals([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], $mock->array);

--- a/tests/Link/SliceTest.php
+++ b/tests/Link/SliceTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * SliceTest.
  *
@@ -22,7 +20,6 @@ class SliceTest extends \PHPUnit\Framework\TestCase
         /** @var Slice $mock */
         $mock        = $this->getMockForTrait(Slice::class);
         $mock->array = [0, 1, 2, 3, 4, 5];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->slice(1, 3);
 
         $this->assertEquals([1, 2, 3], $mock->array);
@@ -37,7 +34,6 @@ class SliceTest extends \PHPUnit\Framework\TestCase
         /** @var Slice $mock */
         $mock        = $this->getMockForTrait(Slice::class);
         $mock->array = [0, 1, 2, 3, 4, 5];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $result      = $mock->slice(1, 3)->array;
         $this->assertEquals([1, 2, 3], $result);
     }

--- a/tests/Link/SortKeysTest.php
+++ b/tests/Link/SortKeysTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * SortKeysTest.
  *
@@ -24,7 +22,6 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['apple' => 4, 'banana' => 3, 'lemon' => 1, 'orange' => 2], $mock->sortKeys()->array);
     }
 
@@ -39,7 +36,6 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['111' => 1, '21' => 2, '112' => 3, '22' => 4];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['21' => 2, '22' => 4, '111' => 1, '112' => 3], $mock->sortKeys()->array);
     }
 
@@ -54,7 +50,6 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['lemon' => 1, 'orange' => 2, 'banana' => 3, 'apple' => 4];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             ['orange' => 2, 'lemon' => 1, 'banana' => 3, 'apple' => 4],
             $mock->sortKeys(SORT_REGULAR, ['reverse' => true])->array
@@ -71,7 +66,6 @@ class SortKeysTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(SortKeys::class);
         $mock->array = ['kiwi' => 2, 'banana' => 3, 'apple' => 4];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
         $this->assertSame(['kiwi' => 2, 'apple' => 4, 'banana' => 3], $mock->sortKeys(function ($a, $b) {
             $a = strlen($a);

--- a/tests/Link/SortTest.php
+++ b/tests/Link/SortTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * SortTest.
  *
@@ -24,7 +22,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['apple', 'banana', 'lemon', 'orange'], $mock->sort()->array);
     }
 
@@ -39,7 +36,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['111', '21', '112', '22'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(['21', '22', '111', '112'], $mock->sort(SORT_NUMERIC)->array);
     }
 
@@ -54,7 +50,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             [3 => 'apple', 2 => 'banana', 0 => 'lemon', 1 => 'orange'],
             $mock->sort(null, ['assoc' => true])->array
@@ -72,7 +67,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             ['orange', 'lemon', 'banana', 'apple'],
             $mock->sort(null, ['reverse' => true])->array
@@ -90,7 +84,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $this->assertSame(
             [1 => 'orange', 0 => 'lemon', 2 => 'banana', 3 => 'apple'],
             $mock->sort(null, ['assoc' => true, 'reverse' => true])->array
@@ -108,7 +101,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['kiwi', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
         $this->assertSame(['kiwi', 'apple', 'banana'], $mock->sort(function ($a, $b): int {
             $a = strlen($a);
@@ -129,7 +121,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sort::class);
         $mock->array = ['kiwi', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         // sort by strlen
         $this->assertSame([0 => 'kiwi', 2 => 'apple', 1 => 'banana'], $mock->sort(function ($a, $b): int {
             $a = strlen($a);
@@ -150,7 +141,6 @@ class SortTest extends \PHPUnit\Framework\TestCase
         $mock = $this->getMockForTrait(Sort::class);
         $mock->array = ['IMG0.png', 'img12.png', 'img10.png', 'img2.png', 'img1.png', 'IMG3.png'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $result = $mock->sort(SORT_NATURAL | SORT_FLAG_CASE);
         $this->assertSame('IMG0.png', $result->array[0]);
         $this->assertSame('img1.png', $result->array[1]);

--- a/tests/Link/SpliceTest.php
+++ b/tests/Link/SpliceTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * SpliceTest.
  *
@@ -23,7 +21,6 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(2);
         $this->assertSame(['lemon', 'orange'], $mock->array);
     }
@@ -38,7 +35,6 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(1, -1);
         $this->assertSame(['lemon', 'apple'], $mock->array);
     }
@@ -53,7 +49,6 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(1, 4, 'kiwi');
         $this->assertSame(['lemon', 'kiwi'], $mock->array);
     }
@@ -68,7 +63,6 @@ class SpliceTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Splice::class);
         $mock->array = ['lemon', 'orange', 'banana', 'apple'];
 
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->splice(-1, 1, ['kiwi', 'pineapple']);
         $this->assertSame(['lemon', 'orange', 'banana', 'kiwi', 'pineapple'], $mock->array);
     }

--- a/tests/Link/UniqueTest.php
+++ b/tests/Link/UniqueTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * UniqueTest.
  *
@@ -22,7 +20,6 @@ class UniqueTest extends \PHPUnit\Framework\TestCase
         /** @var Unique $mock */
         $mock        = $this->getMockForTrait(Unique::class);
         $mock->array = [0, 1, 0, 0];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->unique();
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/UnshiftTest.php
+++ b/tests/Link/UnshiftTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * UnshiftTest.
  *
@@ -22,7 +20,6 @@ class UnshiftTest extends \PHPUnit\Framework\TestCase
         /** @var Unshift $mock */
         $mock        = $this->getMockForTrait(Unshift::class);
         $mock->array = [1];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->unshift(0);
 
         $this->assertEquals([0, 1], $mock->array);

--- a/tests/Link/ValuesTest.php
+++ b/tests/Link/ValuesTest.php
@@ -2,8 +2,6 @@
 
 namespace Cocur\Chain\Link;
 
-use Cocur\Chain\ChainTest;
-
 /**
  * ValuesTest.
  *
@@ -22,7 +20,6 @@ class ValuesTest extends \PHPUnit\Framework\TestCase
         /** @var Values $mock */
         $mock        = $this->getMockForTrait(Values::class);
         $mock->array = ['foo' => 1, 'bar' => 2];
-        $this->expectExceptionMessageRegExp(ChainTest::getFluentTypeErrorForMockedTrait($mock));
         $mock->values();
 
         $this->assertEquals([1, 2], $mock->array);


### PR DESCRIPTION
I rewrote the return types to use `self` instead of `Chain`. This have several advantages:

* remove a lot of clutter
* API isn´t locked on `Chain` being the final class, in other words, you can now subclass `Chain` without breaking fluent design
* mocked interfaces doesn´t need to account for a `TypeError` (removed the fragile test `getFluentTypeErrorForMockedTrait`)

Obsoletes #44 

Kudos to Symfony for making me aware of this superior syntax.