### PR TITLE
Improve assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: nightly
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "autoload": {
         "psr-4": {"Cocur\\Chain\\": "src"}
     },
+    "autoload-dev": {
+        "psr-4": {"Cocur\\Chain\\": "tests"}
+    },
     "require": {
         "php": ">=7.2"
     },

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -148,7 +148,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(isset($c[0]));
         $c[0] = 'foo';
         $this->assertTrue(isset($c[0]));
-        $this->assertEquals('foo', $c[0]);
+        $this->assertSame('foo', $c[0]);
         unset($c[0]);
         $this->assertFalse(isset($c[0]));
     }
@@ -162,7 +162,7 @@ class ChainTest extends \PHPUnit\Framework\TestCase
         $c = Chain::create([0, 1, 2]);
 
         $this->assertInstanceOf(\Countable::class, $c);
-        $this->assertEquals(3, count($c));
+        $this->assertCount(3, $c);
     }
 
     /**
@@ -174,6 +174,6 @@ class ChainTest extends \PHPUnit\Framework\TestCase
         $c = Chain::create([0, 1, 2]);
 
         $this->assertInstanceOf(\JsonSerializable::class, $c);
-        $this->assertEquals('[0,1,2]', json_encode($c));
+        $this->assertSame('[0,1,2]', json_encode($c));
     }
 }

--- a/tests/Link/CountTest.php
+++ b/tests/Link/CountTest.php
@@ -21,6 +21,6 @@ class CountTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Count::class);
         $mock->array = [0, 1, 2, 3];
 
-        $this->assertEquals(4, $mock->count());
+        $this->assertSame(4, $mock->count());
     }
 }

--- a/tests/Link/FindTest.php
+++ b/tests/Link/FindTest.php
@@ -24,7 +24,7 @@ class FindTest extends \PHPUnit\Framework\TestCase
         $result = $mock->find(function ($item): bool {
             return 'bar' === $item;
         });
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
     }
 
     /**

--- a/tests/Link/FirstTest.php
+++ b/tests/Link/FirstTest.php
@@ -21,6 +21,6 @@ class FirstTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(First::class);
         $mock->array = [0, 1, 2, 3];
 
-        $this->assertEquals(0, $mock->first());
+        $this->assertSame(0, $mock->first());
     }
 }

--- a/tests/Link/FlatMapTest.php
+++ b/tests/Link/FlatMapTest.php
@@ -23,8 +23,8 @@ class FlatMapTest extends \PHPUnit\Framework\TestCase
             return [str_replace('bar', 'foo', $v)];
         });
 
-        $this->assertEquals('foofoo', $mock->array[0]);
-        $this->assertEquals('foo', $mock->array[1]);
+        $this->assertSame('foofoo', $mock->array[0]);
+        $this->assertSame('foo', $mock->array[1]);
     }
 
     /**

--- a/tests/Link/JoinTest.php
+++ b/tests/Link/JoinTest.php
@@ -21,6 +21,6 @@ class JoinTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Join::class);
         $mock->array = ['a', 'b', 'c'];
 
-        $this->assertEquals('abc', $mock->join());
+        $this->assertSame('abc', $mock->join());
     }
 }

--- a/tests/Link/LastTest.php
+++ b/tests/Link/LastTest.php
@@ -21,6 +21,6 @@ class LastTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Last::class);
         $mock->array = [0, 1, 2, 3];
 
-        $this->assertEquals(3, $mock->last());
+        $this->assertSame(3, $mock->last());
     }
 }

--- a/tests/Link/MapTest.php
+++ b/tests/Link/MapTest.php
@@ -24,8 +24,8 @@ class MapTest extends \PHPUnit\Framework\TestCase
             return str_replace('bar', 'foo', $v);
         });
 
-        $this->assertEquals('foofoo', $mock->array[0]);
-        $this->assertEquals('foo', $mock->array[1]);
+        $this->assertSame('foofoo', $mock->array[0]);
+        $this->assertSame('foo', $mock->array[1]);
     }
 
     /**

--- a/tests/Link/PopTest.php
+++ b/tests/Link/PopTest.php
@@ -21,7 +21,7 @@ class PopTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Pop::class);
         $mock->array = [0, 1];
 
-        $this->assertEquals(1, $mock->pop());
+        $this->assertSame(1, $mock->pop());
         $this->assertEquals([0], $mock->array);
     }
 }

--- a/tests/Link/ProductTest.php
+++ b/tests/Link/ProductTest.php
@@ -21,6 +21,6 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Product::class);
         $mock->array = [2, 3];
 
-        $this->assertEquals(6, $mock->product());
+        $this->assertSame(6, $mock->product());
     }
 }

--- a/tests/Link/ReduceTest.php
+++ b/tests/Link/ReduceTest.php
@@ -21,7 +21,7 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Reduce::class);
         $mock->array = [1, 2, 3];
 
-        $this->assertEquals(6, $mock->reduce(function ($s, $v) {
+        $this->assertSame(6, $mock->reduce(function ($s, $v) {
             return $s + $v;
         }));
     }

--- a/tests/Link/ReplaceTest.php
+++ b/tests/Link/ReplaceTest.php
@@ -24,9 +24,9 @@ class ReplaceTest extends \PHPUnit\Framework\TestCase
         $mock->array = [0, 1, 2, 3, 4];
         $mock->replace([1 => 42, 3 => 69]);
 
-        $this->assertEquals(0, $mock->array[0]);
-        $this->assertEquals(42, $mock->array[1]);
-        $this->assertEquals(69, $mock->array[3]);
+        $this->assertSame(0, $mock->array[0]);
+        $this->assertSame(42, $mock->array[1]);
+        $this->assertSame(69, $mock->array[3]);
     }
 
     /**
@@ -40,8 +40,8 @@ class ReplaceTest extends \PHPUnit\Framework\TestCase
         $mock->array = [0, 1, 2, 3, 4];
         $mock->replace(Chain::create([1 => 42, 3 => 69]));
 
-        $this->assertEquals(0, $mock->array[0]);
-        $this->assertEquals(42, $mock->array[1]);
-        $this->assertEquals(69, $mock->array[3]);
+        $this->assertSame(0, $mock->array[0]);
+        $this->assertSame(42, $mock->array[1]);
+        $this->assertSame(69, $mock->array[3]);
     }
 }

--- a/tests/Link/SearchTest.php
+++ b/tests/Link/SearchTest.php
@@ -21,6 +21,6 @@ class SearchTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Search::class);
         $mock->array = ['foo', 'bar'];
 
-        $this->assertEquals(1, $mock->search('bar'));
+        $this->assertSame(1, $mock->search('bar'));
     }
 }

--- a/tests/Link/ShiftTest.php
+++ b/tests/Link/ShiftTest.php
@@ -21,7 +21,7 @@ class ShiftTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Shift::class);
         $mock->array = [0, 1];
 
-        $this->assertEquals(0, $mock->shift());
+        $this->assertSame(0, $mock->shift());
         $this->assertEquals([1], $mock->array);
     }
 }

--- a/tests/Link/SumTest.php
+++ b/tests/Link/SumTest.php
@@ -21,6 +21,6 @@ class SumTest extends \PHPUnit\Framework\TestCase
         $mock        = $this->getMockForTrait(Sum::class);
         $mock->array = [1, 2, 3];
 
-        $this->assertEquals(6, $mock->sum());
+        $this->assertSame(6, $mock->sum());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert equals checking strict.
- Add `php7.4` version test on Travis CI build.