### PR TITLE
feat: Add Chain::merge functionality (Close #54)

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -34,6 +34,7 @@ use Cocur\Chain\Link\Reverse;
 use Cocur\Chain\Link\Search;
 use Cocur\Chain\Link\Shift;
 use Cocur\Chain\Link\Shuffle;
+use Cocur\Chain\Link\SimpleMerge;
 use Cocur\Chain\Link\Slice;
 use Cocur\Chain\Link\Some;
 use Cocur\Chain\Link\Sort;
@@ -74,6 +75,7 @@ class Chain extends AbstractChain implements Countable
     use Last;
     use Map;
     use Merge;
+    use SimpleMerge;
     use Pad;
     use Pop;
     use Product;
@@ -157,25 +159,5 @@ class Chain extends AbstractChain implements Countable
     public static function fill(int $startIndex, int $num, $value = null): self
     {
         return new self(array_fill($startIndex, $num, $value));
-    }
-
-    /**
-     * Create a new Chain from multiple arrays.
-     * Creates a new Chain and merges the given arrays
-     * @param array ...$arrays The arrays to merge
-     *
-     * @return self
-     */
-    public static function merge(array &...$arrays): self
-    {
-        $result = [];
-
-        foreach ($arrays as $array) {
-            foreach($array as $item) {
-                $result[] = $item;
-            }
-        }
-
-        return new self($result);
     }
 }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -158,4 +158,24 @@ class Chain extends AbstractChain implements Countable
     {
         return new self(array_fill($startIndex, $num, $value));
     }
+
+    /**
+     * Create a new Chain from multiple arrays.
+     * Creates a new Chain and merges the given arrays
+     * @param array ...$arrays The arrays to merge
+     *
+     * @return self
+     */
+    public static function merge(array &...$arrays): self
+    {
+        $result = [];
+
+        foreach ($arrays as $array) {
+            foreach($array as $item) {
+                $result[] = $item;
+            }
+        }
+
+        return new self($result);
+    }
 }

--- a/src/Link/SimpleMerge.php
+++ b/src/Link/SimpleMerge.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Cocur\Chain\Link;
+
+use Cocur\Chain\Chain;
+
+/**
+ * Simple, therefore quicker merge.
+ * @author    Andrey Tsarev
+ * @copyright 2015-2018 Florian Eckerstorfer
+ */
+trait SimpleMerge
+{
+    /**
+     * Merge arrays.
+     * Merge the elements of one array with the elements of the array in the Chain.
+     * @param Chain|array $array Array to merge with
+     * @return self
+     */
+    public function simpleMerge( $array ) : self
+    {
+        $array = $array instanceof Chain ? $array->array : $array;
+        foreach ($array as $item) {
+            $this->array[] = $item;
+        }
+
+        return $this;
+    }
+}

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -71,6 +71,22 @@ class ChainTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
+     * @covers \Cocur\Chain\Chain::merge()
+     */
+    public function fillCreatesAMergedChain(): void
+    {
+        $array1 = [1,2,3];
+        $array2 = [4,5];
+        $array3 = [6];
+
+        $chain = Chain::merge($array1, $array2, $array3);
+
+        $this->assertIsArray($chain->array);
+        $this->assertCount(6, $chain->array);
+    }
+
+    /**
+     * @test
      */
     public function chainHasTraits(): void
     {

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -71,22 +71,6 @@ class ChainTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @covers \Cocur\Chain\Chain::merge()
-     */
-    public function fillCreatesAMergedChain(): void
-    {
-        $array1 = [1,2,3];
-        $array2 = [4,5];
-        $array3 = [6];
-
-        $chain = Chain::merge($array1, $array2, $array3);
-
-        $this->assertIsArray($chain->array);
-        $this->assertCount(6, $chain->array);
-    }
-
-    /**
-     * @test
      */
     public function chainHasTraits(): void
     {

--- a/tests/Link/SimpleMergeTest.php
+++ b/tests/Link/SimpleMergeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Cocur\Chain\Link;
+
+use Cocur\Chain\Chain;
+
+/**
+ * SimpleMergeTest.
+ *
+ * @author    Andrey Tsarev
+ * @copyright 2015-2018 Florian Eckerstorfer
+ */
+class SimpleMergeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @test
+     * @covers \Cocur\Chain\Link\SimpleMerge::simpleMerge()
+     */
+    public function mergeMergesArray(): void
+    {
+        /** @var SimpleMerge $mock */
+        $mock        = $this->getMockForTrait(SimpleMerge::class);
+        $mock->array = [0, 1, 2];
+        $mock->simpleMerge([3, 4]);
+
+        $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
+    }
+
+    /**
+     * @test
+     * @covers \Cocur\Chain\Link\SimpleMerge::simpleMerge()
+     */
+    public function mergeMergesChain(): void
+    {
+        /** @var SimpleMerge $mock */
+        $mock        = $this->getMockForTrait(SimpleMerge::class);
+        $mock->array = [0, 1, 2];
+        $mock->simpleMerge(Chain::create([3, 4]));
+
+        $this->assertEquals([0, 1, 2, 3, 4], $mock->array);
+    }
+
+}


### PR DESCRIPTION
This should be a bit more efficient than the internal array_merge. It is using references in order to improve speed when using large arrays. It also does not modify passed arrays to avoid unexpected issues for consumers.